### PR TITLE
Optional :produces in action specs

### DIFF
--- a/lib/graphism.ex
+++ b/lib/graphism.ex
@@ -389,7 +389,7 @@ defmodule Graphism do
       |> Enum.each(fn a ->
         action_spec = e[:actions][a]
 
-        unless action_spec && action_spec[:produces] && action_spec[:using] do
+        unless action_spec[:using] do
           raise "entity #{e[:name]} is virtual but does not define a spec for action #{a}"
         end
       end)


### PR DESCRIPTION
[BT-NNNN]

### Description :page_with_curl:

When definiing an action spec, eg:

```
create(produces: :custom_type, using: SomeCustomModule)
```

the `:produces` option is no longer mandatory. If not specified, the mutation will return the entity itself.


### How to test :question:

- FIXME: Add the steps describing how to verify your changes

### TODO :construction:
- [ ] :art: Compare implementation with what's designed, manually
- [ ] :+1: Get 1 approval
