### PR TITLE
Composite keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,4 +4,5 @@
 
 * Lookup arguments - [#44](https://github.com/Gravity-Core/graphism/pull/44) 
 * Client generated ids - [#46](https://github.com/Gravity-Core/graphism/pull/46) 
+* Secondary keys - [#47](https://github.com/Gravity-Core/graphism/pull/47)
 

--- a/README.md
+++ b/README.md
@@ -313,6 +313,33 @@ end
 This will stop Graphism from generating ids for you. However you will still need to pass in a valid
 UUID v4 string.
 
+### Composite keys
+
+By default, Graphism uses UUIDs as primary keys, and, as you've already seen, it is also possible to define
+unique keys, such as a name, or an email, using the `unique(string(:name))` or `unique(string(:email))` notation.
+
+But sometimes unique keys are made of more than just one field:
+
+```elixir
+entity :user do
+  unique(string(:name))
+end
+      
+entity :organisation do 
+  unique(string(:name))
+end
+
+entity :membership do
+  belongs_to(:user)
+  belongs_to(:organisation)
+  key([:user, :organisation]) # <-- composite key
+  action(:read)
+end
+```
+
+In the above example, we are saying that a user can belong to an organisation only once. Graphism will take
+care of creating the right indices and GraphQL queries for you.
+
 ### Hooks
 
 Hooks are a mechanism in Graphism for customization. They are implemented as standard OTP behaviours.

--- a/test/key_test.exs
+++ b/test/key_test.exs
@@ -1,0 +1,45 @@
+defmodule Analytic.KeyTest do
+  use Graphism.Case
+
+  describe "keys" do
+    defmodule Schema do
+      use Graphism, repo: TestRepo
+
+      allow(AllowEverything)
+
+      entity :user do
+        unique(string(:name))
+        action(:list)
+      end
+
+      entity :organisation do
+        unique(string(:country))
+        unique(string(:name))
+        key([:country, :name])
+        action(:read)
+      end
+
+      entity :membership do
+        belongs_to(:user)
+        belongs_to(:organisation)
+        key([:user, :organisation])
+        action(:read)
+        action(:create)
+      end
+    end
+
+    test "can be defined on relations" do
+      query = query!(:membership, :by_user_and_organisation)
+
+      assert arg?(query, :user)
+      assert arg?(query, :organisation)
+    end
+
+    test "can be defined on attributes" do
+      query = query!(:organisation, :by_country_and_name)
+
+      assert arg?(query, :country)
+      assert arg?(query, :name)
+    end
+  end
+end

--- a/test/support/case.ex
+++ b/test/support/case.ex
@@ -4,13 +4,44 @@ defmodule Graphism.Case do
       use ExUnit.Case
 
       defp mutation(entity, name, schema \\ __MODULE__.Schema) do
-        type = String.to_atom("#{entity}_mutations")
-        mutations = Absinthe.Schema.lookup_type(schema, type)
-        Map.get(mutations.fields, name)
+        field(entity, :mutations, name, schema)
       end
 
-      defp args(mutation), do: mutation.args
-      defp arg?(mutation, arg), do: mutation |> args() |> Map.has_key?(arg)
+      defp mutation!(entity, name, schema \\ __MODULE__.Schema) do
+        field!(entity, :mutations, name, schema)
+      end
+
+      defp query(entity, name, schema \\ __MODULE__.Schema) do
+        field(entity, :queries, name, schema)
+      end
+
+      defp query!(entity, name, schema \\ __MODULE__.Schema) do
+        field!(entity, :queries, name, schema)
+      end
+
+      defp field!(entity, kind, name, schema \\ __MODULE__.Schema) do
+        field = field(entity, kind, name, schema)
+
+        unless field do
+          raise "no such field #{name} (under #{kind}) for #{entity} in #{inspect(schema)}"
+        end
+
+        field
+      end
+
+      defp field(entity, kind, name, schema \\ __MODULE__.Schema) do
+        type_name = String.to_atom("#{entity}_#{kind}")
+        type = Absinthe.Schema.lookup_type(schema, type_name)
+
+        unless type do
+          raise "no #{kind} for #{entity} in #{inspect(schema)}"
+        end
+
+        Map.get(type.fields, name)
+      end
+
+      defp args(field), do: field.args
+      defp arg?(field, arg), do: field |> args() |> Map.has_key?(arg)
     end
   end
 end


### PR DESCRIPTION
### Description

Completes composite key support to Graphism.

This feature was partially implemented. Now we also support it for keys based on relations.

```elixir
entity :user do
  unique(string(:name))
end
      
entity :organisation do 
  unique(string(:name))
end

entity :membership do
  belongs_to(:user)
  belongs_to(:organisation)
  key([:user, :organisation]) # <-- composite key
  action(:read)
end
```

 
### Checklist

- [x] Added or modified tests 
- [x] Added an entry to the CHANGELOG
