### PR TITLE
Graceful foreign key constraint validations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,4 +5,5 @@
 * Lookup arguments - [#44](https://github.com/Gravity-Core/graphism/pull/44) 
 * Client generated ids - [#46](https://github.com/Gravity-Core/graphism/pull/46) 
 * Composite keys - [#47](https://github.com/Gravity-Core/graphism/pull/47)
+* Graceful foreign key constraint validations - [#48](https://github.com/Gravity-Core/graphism/pull/48)
 

--- a/lib/graphism.ex
+++ b/lib/graphism.ex
@@ -1063,6 +1063,27 @@ defmodule Graphism do
               end
             end)
           )
+
+          unquote_splicing(
+            e
+            |> parent_relations()
+            |> Enum.map(fn rel ->
+              constraint = Migrations.foreign_key_constraint_from_relation(e, rel)
+              name = constraint[:name]
+              field = constraint[:field]
+              message = "referenced data does not exist"
+
+              quote do
+                changes =
+                  changes
+                  |> foreign_key_constraint(
+                    unquote(field),
+                    name: unquote(name),
+                    message: unquote(message)
+                  )
+              end
+            end)
+          )
         end
 
         def delete_changeset(e) do

--- a/lib/migrations.ex
+++ b/lib/migrations.ex
@@ -119,6 +119,12 @@ defmodule Graphism.Migrations do
     })
   end
 
+  def foreign_key_constraint_from_relation(e, rel) do
+    field = "#{e[:name]}_#{rel[:name]}"
+    name = "#{e[:table]}_#{rel[:name]}_id_fkey"
+    [name: String.to_atom(name), field: String.to_atom(field)]
+  end
+
   def indices_from_attributes(e) do
     e[:attributes]
     |> Enum.filter(&unique?(&1))


### PR DESCRIPTION
### Description

Implements graceful handling of foreign key constraints, by adding to the create changesets.
This is a bit tricky to test without a proper database and a migrated schema. 

### Checklist

- [ ] ~~Added or modified tests~~ 
- [x] Added an entry to the CHANGELOG
