### PR TITLE
More flexible entity fetch on api create/update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,4 @@
 * Composite keys - [#47](https://github.com/Gravity-Core/graphism/pull/47)
 * Graceful foreign key constraint validations - [#48](https://github.com/Gravity-Core/graphism/pull/48)
 * Optional preloads - [#49](https://github.com/Gravity-Core/graphism/pull/49)
+* More flexible entity fetch on api create/update - [#50](https://github.com/Gravity-Core/graphism/pull/50)

--- a/lib/graphism.ex
+++ b/lib/graphism.ex
@@ -2476,7 +2476,7 @@ defmodule Graphism do
 
     refetch =
       quote do
-        {:ok, unquote(var(e))} <- get_by_id(unquote(var(e)).id)
+        {:ok, unquote(var(e))} <- get_by_id(unquote(var(e)).id, opts)
       end
 
     before_hooks = hooks(e, :before, :create)
@@ -2544,7 +2544,7 @@ defmodule Graphism do
 
     refetch =
       quote do
-        {:ok, unquote(var(e))} <- get_by_id(unquote(var(e)).id)
+        {:ok, unquote(var(e))} <- get_by_id(unquote(var(e)).id, opts)
       end
 
     before_hooks = hooks(e, :before, :update)
@@ -2559,7 +2559,8 @@ defmodule Graphism do
                 |> vars()
               ),
               unquote(var(e)),
-              attrs
+              attrs,
+              opts \\ []
             ) do
           unquote(repo_module).transaction(fn ->
             with unquote_splicing(


### PR DESCRIPTION
### Description

This change allows for a more flexible policy when fetching an entity after creating or updating it via the Elixir api.

Specifically, all supported preloads options from the `get_by_id` api functions are now also supported when mutating existing entities.

### Checklist

- [ ] ~~Added or modified tests~~ 
- [x] Added an entry to the CHANGELOG
