### PR TITLE
Ability to chain after hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Ability to chain after hooks - [#53](https://github.com/Gravity-Core/graphism/pull/53)
+
 ## 0.2.0 (Dec 3rd, 2021)
 
 * Support for dates without time information - [#51](https://github.com/Gravity-Core/graphism/pull/51)
@@ -9,5 +11,5 @@
 * Optional preloads - [#49](https://github.com/Gravity-Core/graphism/pull/49)
 * Graceful foreign key constraint validations - [#48](https://github.com/Gravity-Core/graphism/pull/48)
 * Composite keys - [#47](https://github.com/Gravity-Core/graphism/pull/47)
-* Client generated ids - [#46](https://github.com/Gravity-Core/graphism/pull/46) 
-* Lookup arguments - [#44](https://github.com/Gravity-Core/graphism/pull/44) 
+* Client generated ids - [#46](https://github.com/Gravity-Core/graphism/pull/46)
+* Lookup arguments - [#44](https://github.com/Gravity-Core/graphism/pull/44)

--- a/lib/graphism.ex
+++ b/lib/graphism.ex
@@ -2405,7 +2405,7 @@ defmodule Graphism do
 
   defp hook_call(e, mod, :after, _) do
     quote do
-      {:ok, _} <- unquote(mod).execute(unquote(var(e)))
+      {:ok, unquote(var(e))} <- unquote(mod).execute(unquote(var(e)))
     end
   end
 


### PR DESCRIPTION
### Description

Adds the ability to chain after hooks, by not discarding the output from one hook, so that it can be used as the input for the next one.

### Checklist

- [ ] ~~Added or modified tests~~
- [x] Added an entry to the CHANGELOG
