### PR TITLE
Support optional computed attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Support optional computed attributes - [#61](https://github.com/Gravity-Core/graphism/pull/61)
+
 ## 0.3.0 (Dec 28th, 2021)
 
 * File uploads - [#59](https://github.com/Gravity-Core/graphism/pull/59)

--- a/lib/graphism.ex
+++ b/lib/graphism.ex
@@ -1735,7 +1735,10 @@ defmodule Graphism do
               unquote(var(attr)) <- get_in(context, unquote(from))
             end,
             quote do
-              args <- Map.put(args, unquote(attr[:name]), unquote(var(attr)).id)
+              unquote(var(attr)) <- Map.get(unquote(var(attr)), :id)
+            end,
+            quote do
+              args <- Map.put(args, unquote(attr[:name]), unquote(var(attr)))
             end
           ]
 


### PR DESCRIPTION
### Description

Support for computed optional attributes, eg when we do:

```
optional(string(:user_id), from_context: [:user])
```

then take into consideration that the `:id` property might be null.

### Checklist

- [ ] ~~Added or modified tests~~ 
- [x] Added an entry to the CHANGELOG
