### PR TITLE
Self referencing entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Self referencing entities - [#65](https://github.com/Gravity-Core/graphism/pull/65)
+
 ## 0.3.2 (Jan 15th, 2022)
 
 * Absinthe middleware - [#63](https://github.com/Gravity-Core/graphism/pull/63)

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ end
 
 For convenience, `Plug.Cowboy` is automatically downloaded by Graphism, so you don't need to add it to your project.
 
-## Schema Features :abacus:
+## Schema Features
 
 ### Unique attributes
 
@@ -242,6 +242,17 @@ However, since they are computed, they won't be included in your mutations, ther
 ```elixir
 entity :post do
   computed(boolean(:draft, default: true)
+  ...
+end
+```
+
+### Self referencing entities
+
+Sometimes it is useful to have schemas where an entity needs to reference itself, eg when building a tree-like structure:
+
+```elixir
+entity :node do
+  maybe(belongs_to(:node, as: :parent))
   ...
 end
 ```


### PR DESCRIPTION
### Description

Adds the ability to "nest" entities in order to build recursive, tree-like data structures:

```elixir
entity :node do
  maybe(belongs_to(:node, as: :parent)
end
```

### Checklist

- [ ] Added or modified tests 
- [x] Added an entry to the CHANGELOG
