### PR TITLE
Release 0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.3.3 (Feb 1st, 2022)
+
 * Self referencing entities - [#65](https://github.com/Gravity-Core/graphism/pull/65)
 
 ## 0.3.2 (Jan 15th, 2022)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Graphism.MixProject do
   def project do
     [
       app: :graphism,
-      version: "0.3.2",
+      version: "0.3.3",
       elixir: "~> 1.11",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
### Description

Release v0.3.3:

* Self referencing entities - [#65](https://github.com/Gravity-Core/graphism/pull/65)

### Checklist

- [ ] Added or modified tests 
- [x] Added an entry to the CHANGELOG
