### PR TITLE
Non empty fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Non empty fields - [#75](https://github.com/Gravity-Core/graphism/pull/75)
+
 ## 0.3.7 (March 7th, 2022)
 
 * Immutable fields - [#74](https://github.com/Gravity-Core/graphism/pull/74)

--- a/README.md
+++ b/README.md
@@ -286,6 +286,18 @@ entity :file do
 end
 ```
 
+### Non empty fields
+
+Sometimes we need fields that are optional at the api level, while ensuring non empty values are stored in the database:
+
+```elixir
+entity :file do
+  ...
+  optional(non_empty(string(:name))
+  ...
+end
+```
+
 ### Standard actions
 
 Graphism provides with five basic standard actions:


### PR DESCRIPTION
### Description

This feature is useful when we have fields that might be optional at the api level, but we still need to ensure that non-empty values will always be stored in the database:

```elixir
entity :file do
  optional(non_empty(string(:name)))
end
```

This will allow us to customise the value of `name` while ensuring non-blank values will ever hit the database.


### Checklist

- [ ] Added or modified tests 
- [x] Added an entry to the CHANGELOG
