### PR TITLE
Virtual syntax sugar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Virtual field syntax sugar - [#79](https://github.com/Gravity-Core/graphism/pull/79)
+
 ## 0.3.9 (March 17th, 2022)
 
 * Field validation improvements - [#77](https://github.com/Gravity-Core/graphism/pull/77)

--- a/lib/graphism.ex
+++ b/lib/graphism.ex
@@ -715,6 +715,9 @@ defmodule Graphism do
   defmacro non_empty(_name, _opts \\ []) do
   end
 
+  defmacro virtual(_name, _opts \\ []) do
+  end
+
   defp without_nils(enum) do
     Enum.reject(enum, fn item -> item == nil end)
   end
@@ -3535,6 +3538,13 @@ defmodule Graphism do
   defp attribute({:non_empty, _, [opts]}) do
     with attr when attr != nil <- attribute(opts) do
       modifiers = [:non_empty | get_in(attr, [:opts, :modifiers]) || []]
+      put_in(attr, [:opts, :modifiers], modifiers)
+    end
+  end
+
+  defp attribute({:virtual, _, [opts]}) do
+    with attr when attr != nil <- attribute(opts) do
+      modifiers = [:virtual | get_in(attr, [:opts, :modifiers]) || []]
       put_in(attr, [:opts, :modifiers], modifiers)
     end
   end


### PR DESCRIPTION
### Description

Support for `virtual` syntax sugar:

```elixir
entity :token do
  ...
  virtual(integer(:expires))
  ...
end
``` 

### Checklist

- [ ] Added or modified tests 
- [x] Added an entry to the CHANGELOG
