### PR TITLE
Skippable migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-* Virtual field syntax sugar - [#79](https://github.com/Gravity-Core/graphism/pull/79)
+
+* Skippable migrations - [#80](https://github.com/Gravity-Core/graphism/pull/80)
 
 ## 0.3.9 (March 17th, 2022)
 

--- a/README.md
+++ b/README.md
@@ -426,3 +426,19 @@ Custom Absinthe middlewares can be also be plugged:
 use Graphism, repo: ..., middleware: [My.Middleware]
 ```
 
+### Skippable migrations
+
+Sometimes we need to write our own custom migrations. It is possible to tell Graphism to ignore these
+by setting the `@graphism` module attribute:
+
+```elixir
+defmodule My.Custom.Migration do
+  use Ecto.Migration
+
+  @graphism [:skip] # add the :skip option
+
+  def up do
+    execute("...")
+  end
+end
+```


### PR DESCRIPTION
### Description

Adds the ability to tell Graphism to skip migrations: 

```
defmodule My.Custom.Migration do
  use Ecto.Migration

  @graphism [:skip] # add the :skip option

  def up do
    execute("...")
  end
end
```

### Checklist

- [ ] ~~Added or modified tests~~ 
- [x] Added an entry to the CHANGELOG
