### PR TITLE
Sorting and paginating queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Sorting and paginating queries - [#82](https://github.com/Gravity-Core/graphism/pull/82)
+
 ## 0.3.10 (April 2nd, 2022)
 
 * Skippable migrations - [#80](https://github.com/Gravity-Core/graphism/pull/80)

--- a/README.md
+++ b/README.md
@@ -442,3 +442,32 @@ defmodule My.Custom.Migration do
   end
 end
 ```
+
+### GraphQL pagination and sorting
+
+Graphism will build all your queries with optional sorting and pagination. 
+
+Based on this simple entity:
+
+```elixir
+entity :contact do
+  string(:first_name)
+  string(:last_name)
+  action(:list)
+end
+```
+
+You can query all your contacts by chunks:
+
+```
+query {
+  contacts {
+    all(sortBy: "lastName", sortDirection: ASC, limit: 20, offset: 40) {
+      firstName,
+      lastName
+    }
+  }
+}
+```
+
+


### PR DESCRIPTION
### Description

Adds sorting and paginating capabilities to all GraphQL queries. Eg:

```elixir
 entity :contact do
   string(:first_name)
   string(:last_name)
   action(:list)
 end
 ```

 You can query all your contacts by chunks:

 ```
 query {
   contacts {
     all(sortBy: "lastName", sortDirection: ASC, limit: 20, offset: 40) {
       firstName,
       lastName
     }
   }
 }
 ```


### Checklist

- [ ] ~~Added or modified tests~~ 
- [x] Added an entry to the CHANGELOG
