### PR TITLE
Use aggregateAll instead of aggregate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 # 0.4.1 (April 22th, 2022)
 
 * Aggregate queries - [#84](https://github.com/Gravity-Core/graphism/pull/84)
+* Use aggregateAll instead of aggregate - [#85](https://github.com/Gravity-Core/graphism/pull/85)
+
 
 ## 0.4.0 (April 15th, 2022)
 

--- a/README.md
+++ b/README.md
@@ -478,7 +478,7 @@ In addition to listing entities, it is also possible to aggregate (eg. count) th
 ````
 query {
   contacts {
-    aggregate {
+    aggregateAll {
       count
     }
   }

--- a/lib/graphism.ex
+++ b/lib/graphism.ex
@@ -1707,9 +1707,9 @@ defmodule Graphism do
     end)
   end
 
-  defp resolver_aggregate_fun(e, _schema, api_module) do
+  defp resolver_aggregate_all_fun(e, _schema, api_module) do
     quote do
-      def aggregate(_, args, %{context: context}) do
+      def aggregate_all(_, args, %{context: context}) do
         unquote(simple_auth_context(e, :list))
 
         with true <- should_list?(args, context) do
@@ -1746,7 +1746,7 @@ defmodule Graphism do
 
   defp with_resolver_aggregate_funs(funs, e, schema, api_module) do
     with_entity_funs(funs, e, :list, fn ->
-      [resolver_aggregate_fun(e, schema, api_module)] ++
+      [resolver_aggregate_all_fun(e, schema, api_module)] ++
         resolver_aggregate_by_relation_funs(e, schema, api_module)
     end)
   end
@@ -3227,8 +3227,8 @@ defmodule Graphism do
   defp graphql_query_aggregate_all(e, _schema) do
     quote do
       @desc "Aggregate all " <> unquote("#{e[:plural_display_name]}")
-      field :aggregate, non_null(:aggregate) do
-        resolve(&unquote(e[:resolver_module]).aggregate/3)
+      field :aggregate_all, non_null(:aggregate) do
+        resolve(&unquote(e[:resolver_module]).aggregate_all/3)
       end
     end
   end


### PR DESCRIPTION
### Description

Use `aggregateAll` instead of `aggregate` as the query name, for better consistency with `list` queries.

### Checklist

- [ ] ~~Added or modified tests~~ 
- [x] Added an entry to the CHANGELOG
