### PR TITLE
More accurate primary keys in relations with aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* More accurate primary keys in relations with aliases - [#89](https://github.com/Gravity-Core/graphism/pull/89)
+
 ## 0.4.3 (April 26th, 2022)
 
 * More flexible query pagination - [#87](https://github.com/Gravity-Core/graphism/pull/87)


### PR DESCRIPTION
### Description

More accurate definition of primary keys in schemas, when dealing with parent-children relations with aliases. With this, Graphism will always explicitly say which is the primary key column, supporting the special use case of relations with aliases. 


### Checklist

- [ ] Added or modified tests 
- [x] Added an entry to the CHANGELOG
