### PR TITLE
Better migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Better migrations - [#90](https://github.com/Gravity-Core/graphism/pull/90)
 * More accurate primary keys in relations with aliases - [#89](https://github.com/Gravity-Core/graphism/pull/89)
 
 ## 0.4.3 (April 26th, 2022)


### PR DESCRIPTION
### Description

Use a better ordering in migrations. For example, if we are renaming an enum, create the new enum first, use it in ables, then drop the old enum.

### Checklist

- [ ] Added or modified tests 
- [x] Added an entry to the CHANGELOG
