### PR TITLE
Cascade deletes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Cascade deletes - [#91](https://github.com/Gravity-Core/graphism/pull/91)
 * Better migrations - [#90](https://github.com/Gravity-Core/graphism/pull/90)
 * More accurate primary keys in relations with aliases - [#89](https://github.com/Gravity-Core/graphism/pull/89)
 

--- a/README.md
+++ b/README.md
@@ -475,7 +475,7 @@ query {
 
 In addition to listing entities, it is also possible to aggregate (eg. count) them. 
 
-````
+```
 query {
   contacts {
     aggregateAll {
@@ -484,3 +484,19 @@ query {
   }
 }
 ```
+
+### Cascade deletes
+
+By default, it is not possible to delete an entity if it has children entities pointing to it. But this can be
+overriden on a per-relation basis:
+
+```elixir
+entity :node do
+  ...
+  belongs_to(:node, as: parent, delete: :cascade)
+  ...
+end
+```
+
+Graphism will take of writing the correct migrations, including dropping existing constraints, in order to fully support
+changes in this policy.


### PR DESCRIPTION
### Description

Adds support for cascade deletes in Graphism. This can be defined on a per relation basis:

```elixir
entity :node do
  belongs_to(:node, as: parent, delete: :cascade)
end
```

### Checklist

- [ ] Added or modified tests 
- [x] Added an entry to the CHANGELOG
