### PR TITLE
Pass parent structs to before hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Pass parent structs to before hooks - [#92](https://github.com/Gravity-Core/graphism/pull/92)
 * Cascade deletes - [#91](https://github.com/Gravity-Core/graphism/pull/91)
 * Better migrations - [#90](https://github.com/Gravity-Core/graphism/pull/90)
 * More accurate primary keys in relations with aliases - [#89](https://github.com/Gravity-Core/graphism/pull/89)


### PR DESCRIPTION
### Description

An internal improvement so that we also have access to parent structs (not just their ids) in before hooks.

### Checklist

- [ ] Added or modified tests 
- [x] Added an entry to the CHANGELOG
