### PR TITLE
Introspection enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Introspection enhancements - [#94](https://github.com/Gravity-Core/graphism/pull/94)
+
 ## 0.4.4 (May 5th, 2022)
 
 * Pass parent structs to before hooks - [#92](https://github.com/Gravity-Core/graphism/pull/92)


### PR DESCRIPTION
### Description

Adds a couple of introspection enhancements:

* A more robust `column_name/1` function so that we can easily resolve a entity field into a column, in different contexts.
* The graphism context is now enriched with the schema module of the entities involved in the current context. If we are evaluating a relationship field between two entities, the context will contain both source and the target entity schemas.

### Checklist

- [ ] Added or modified tests 
- [x] Added an entry to the CHANGELOG
