### PR TITLE
Add :text attribute type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 ## Unreleased
 
+* Add `:text` attribute type - [#97](https://github.com/Gravity-Core/graphism/pull/97)
 * Introspection enhancements
-  * Add `column_type/1` to entity schema mmodule [#94](https://github.com/Gravity-Core/graphism/pull/94)
-  * Add `column_name/1` to entity schema module [#96](https://github.com/Gravity-Core/graphism/pull/94)
+  * Add `column_type/1` to entity schema mmodule - [#94](https://github.com/Gravity-Core/graphism/pull/94)
+  * Add `column_name/1` to entity schema module - [#96](https://github.com/Gravity-Core/graphism/pull/96)
 
 ## 0.4.4 (May 5th, 2022)
 

--- a/lib/graphism.ex
+++ b/lib/graphism.ex
@@ -708,6 +708,9 @@ defmodule Graphism do
   defmacro string(_name, _opts \\ []) do
   end
 
+  defmacro text(_name, _opts \\ []) do
+  end
+
   defmacro integer(_name, _opts \\ []) do
   end
 
@@ -1138,6 +1141,7 @@ defmodule Graphism do
           unquote_splicing(
             e[:attributes]
             |> Enum.filter(fn attr -> attr[:kind] == :string end)
+            |> Enum.reject(fn attr -> attr[:opts][:store] == :text end)
             |> Enum.map(fn attr ->
               quote do
                 changes =
@@ -1468,7 +1472,7 @@ defmodule Graphism do
         unless inverse_rel do
           raise """
             Could not find inverse for :has_many relation #{rel[:name]} of #{e[:name]} in
-            #{inspect(inverse_rels)} of #{target[:name]} 
+            #{inspect(inverse_rels)} of #{target[:name]}
           """
         end
 
@@ -3920,6 +3924,7 @@ defmodule Graphism do
   end
 
   defp attribute({:string, _, [name]}), do: attribute([name, :string])
+  defp attribute({:text, _, [name]}), do: attribute([name, :string, [store: :text]])
   defp attribute({:integer, _, [name]}), do: attribute([name, :integer])
   defp attribute({:boolean, _, [name]}), do: attribute([name, :boolean])
   defp attribute({:float, _, [name]}), do: attribute([name, :float])

--- a/lib/migrations.ex
+++ b/lib/migrations.ex
@@ -440,7 +440,7 @@ defmodule Graphism.Migrations do
                  %{
                    column: col,
                    type: column_stored_type(column),
-                   opts: column[:opts],
+                   opts: column[:opts] |> Keyword.drop([:store]),
                    action: :add,
                    kind: :column
                  }


### PR DESCRIPTION
### Description

Supports long strings of text: 

```elixir
entity :article do
  text(:content)
end
```

At the api level, these will be strings. But in Postgres, they will be stored as `TEXT`, with no particular validation on the length of the string.

### Checklist

- [ ] Added or modified tests 
- [x] Added an entry to the CHANGELOG
