### PR TITLE
Fix support for text attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 0.5.1 (June 14th, 2022)
+
+* Fix support for `:text` attributes - [#98](https://github.com/Gravity-Core/graphism/pull/98)
+
 ## 0.5.0 (June 13th, 2022)
 
 * Add `:text` attribute type - [#97](https://github.com/Gravity-Core/graphism/pull/97)

--- a/lib/migrations.ex
+++ b/lib/migrations.ex
@@ -674,7 +674,13 @@ defmodule Graphism.Migrations do
   end
 
   defp migration_from_column(col, spec, action) do
-    %{column: col, type: spec[:type], opts: spec[:opts], action: action, kind: :column}
+    %{
+      column: col,
+      type: column_stored_type(spec),
+      opts: spec[:opts] |> Keyword.drop([:store]),
+      action: action,
+      kind: :column
+    }
   end
 
   defp read_migrations(migrations) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Graphism.MixProject do
   def project do
     [
       app: :graphism,
-      version: "0.4.4",
+      version: "0.5.1",
       elixir: "~> 1.11",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
### Description

Fixes support for the new `:text` attribute type, which was partially broken in its first release. 

### Checklist

- [ ] Added or modified tests 
- [x] Added an entry to the CHANGELOG
