### PR TITLE
Json type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Json type - [#100](https://github.com/Gravity-Core/graphism/pull/100)
 * Improved schema Introspection - [#99](https://github.com/Gravity-Core/graphism/pull/99)
 
 ## 0.5.1 (June 14th, 2022)

--- a/README.md
+++ b/README.md
@@ -525,3 +525,49 @@ iex> MyBlog.Schema.Comment.field_specs({:belongs_to, MyBlog.Schema.Post})
 [{:belongs_to, :blog, MyBlog.Schema.Post, :blog_id}]
 ```
 
+### Json types
+
+Graphism allows you to define attributes of `json` type in order to store unstructured data as maps or arrays:
+
+```elixir
+entity :color do
+  json(:data)
+  action(:create)
+  action(:list)
+end
+```
+
+With this, you can define the `data` as a string value in your mutation:
+
+```graphql
+mutation {
+  color{
+    create(data: "{ \"r\": 255, \"g\": 0, \"b\": 0 }") {
+     id,
+     data 
+    }
+  }
+}
+```
+
+And you will get the data back as json:
+
+```json
+{
+  "data": {
+    "color": {
+      "create": {
+        "id": "eb40ddfb-2208-4588-b57f-0931fa18c0fe",
+        "data": {
+          "b": 0,
+          "g": 0,
+          "r": 255
+        }
+      }
+    }
+  }
+}
+```
+
+
+

--- a/lib/type/ecto/jsonb.ex
+++ b/lib/type/ecto/jsonb.ex
@@ -1,0 +1,18 @@
+defmodule Graphism.Type.Ecto.Jsonb do
+  use Ecto.Type
+
+  def type, do: :map
+
+  def cast(data) when is_list(data) or is_map(data) do
+    {:ok, data}
+  end
+
+  def cast(_), do: :error
+
+  def load(data) when is_list(data) or is_map(data) do
+    {:ok, data}
+  end
+
+  def dump(data) when is_list(data) or is_map(data), do: {:ok, data}
+  def dump(_), do: :error
+end

--- a/lib/type/graphql/json.ex
+++ b/lib/type/graphql/json.ex
@@ -1,0 +1,29 @@
+defmodule Graphism.Type.Graphql.Json do
+  @moduledoc false
+
+  use Absinthe.Schema.Notation
+
+  scalar :json, name: "Json" do
+    description("""
+    The `Json` scalar type represents arbitrary json string data, represented as UTF-8
+    character sequences. The Json type is most often used to represent a free-form
+    human-readable json string.
+    """)
+
+    serialize(&encode_json/1)
+    parse(&decode_json/1)
+  end
+
+  defp decode_json(%{value: value}) do
+    case Jason.decode(value) do
+      {:ok, result} -> {:ok, result}
+      _ -> :error
+    end
+  end
+
+  defp decode_json(%Absinthe.Blueprint.Input.Null{}), do: {:ok, nil}
+
+  defp decode_json(_other), do: :error
+
+  defp encode_json(value), do: value
+end


### PR DESCRIPTION
### Description

Adds the `:json` type to Graphism. For example if we define the following schema:

```elixir
entity :color do
  json(:data)
  action(:create)
  action(:list)
end
```

then we can stick any json in the `data` attribute, as long as it is properly escaped:

```graphql
mutation {
  color{
    create(data: "{ \"r\": 255, \"g\": 0, \"b\": 0 }") {
     id,
     data 
    }
  }
}
```

and we can get it back as properly encoded json:
 
```json
{
  "data": {
    "color": {
      "create": {
        "id": "eb40ddfb-2208-4588-b57f-0931fa18c0fe",
        "data": {
          "b": 0,
          "g": 0,
          "r": 255
        }
      }
    }
  }
}
```




### Checklist

- [ ] Added or modified tests 
- [x] Added an entry to the CHANGELOG
