### PR TITLE
Manual preloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Optimized preloads - [#102](https://github.com/Gravity-Core/graphism/pull/102)
+* Manual preloads - [#103](https://github.com/Gravity-Core/graphism/pull/103)
 
 ## 0.6.0 (June 24th, 2022)
 


### PR DESCRIPTION
### Description

This is a significant change that moves towards manual preloads, rather than Graphism trying to be too smart. As part of this:

* `ContextBuilder` is no longer needed. This convenient, but also a bit of a code smell, and it is good that is now gone.
* A new  `paths_to/1` has been added to each schema module. This allows to perform hierarchy discovery:

```elixir
iex> MySchema.Post.paths_to(:user)
[[:user], [:blog, :user]]
```

### Checklist

- [ ] Added or modified tests 
- [x] Added an entry to the CHANGELOG
