### PR TITLE
Authorization telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Authorization telemetry - [#107](https://github.com/Gravity-Core/graphism/pull/107)
 * Custom queries - [#105](https://github.com/Gravity-Core/graphism/pull/105)
 * Optional entity refetch - [#104](https://github.com/Gravity-Core/graphism/pull/104)
 * Manual preloads - [#103](https://github.com/Gravity-Core/graphism/pull/103)

--- a/README.md
+++ b/README.md
@@ -585,5 +585,16 @@ And you will get the data back as json:
 }
 ```
 
+### Telemetry
+
+Graphism instruments calls to external authorization modules and publishes the following telemetry events:
+
+* `[:graphism, :allow, :stop]` when checking access to actions, attributes or relations.
+* `[:graphism, :scope, :stop]` when scoping queries.
+
+For both events, the measurement is `:duration` in native unit. The telemetry metadata has keys `:entity`, `:kind` (eg,
+``:action`, `:attribute`, `:relation`) and `value` (eg, `:list` or `:posts`).
+
+You can also subscribe to the `[:start]` and `[:exception]` events. Internally, Graphism relies on `:telemetry.span/3`.
 
 


### PR DESCRIPTION
### Description

Adds telemetry events for external authorisation calls:

* `[:graphism, :allow, :stop]`
* `[:graphism, :scope, :stop]`

Measurement is given by `:duration` and metadata has keys: `:entity`, `:kind`, and `:value`.

### Checklist

- [ ] Added or modified tests 
- [x] Added an entry to the CHANGELOG
