### PR TITLE
REST Api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* REST Api - [#119](https://github.com/Gravity-Core/graphism/pull/119)
+
 ## 0.7.3 (July 23rd, 2022)
 
 * Introduce mix graphism.new - [#118](https://github.com/Gravity-Core/graphism/pull/118)

--- a/README.md
+++ b/README.md
@@ -603,3 +603,38 @@ Graphism emits telemetry events for various operations and publishes their durat
 | `[:graphism, :relation, :stop]` | `:duration` | `:entity`, `:relation` |
 
 You can also subscribe to the `[:start]` and `[:exception]` events, since Graphism relies on `:telemetry.span/3`.
+
+### REST
+
+Since v0.8.0, Graphism now also generates a REST api for your schema. 
+
+To enable this, select the `:rest` style:
+
+```elixir
+defmodule MySchema do
+  use Graphism, repo: MyRepo, styles: [:rest] 
+end
+```
+
+Graphism will then generate a router module for your schema, an OpenApi 3.0 spec and a RedocUI static html so that you
+can easily discover your api.
+
+Sample configuration using Plug:
+
+```elixir
+defmodule MyRouter do
+  use Plug.Router
+  
+  plug(Plug.Parsers,
+      parsers: [:urlencoded, :multipart, :json],
+      pass: ["*/*"],
+      json_decoder: Jason
+  )
+  plug :match
+  plug :dispatch
+  ...
+  forward("/api", to: MySchema.Router)
+  get("/redoc", to: MySchema.RedocUI, init_opts: [spec_url: "/api/openapi.json"])>
+  ...
+end
+```

--- a/lib/graphism/encoder.ex
+++ b/lib/graphism/encoder.ex
@@ -1,0 +1,41 @@
+defmodule Graphism.Encoder do
+  @moduledoc "Provides encoder modules for entitites"
+
+  alias Graphism.Entity
+
+  def json_modules(schema) do
+    Enum.map(schema, fn e -> json_module(e, schema) end)
+  end
+
+  defp json_module(e, _schema) do
+    attributes = (e |> Entity.public_attributes() |> Entity.names()) ++ [:inserted_at, :updated_at]
+
+    relations =
+      e
+      |> Entity.parent_relations()
+      |> Enum.map(fn rel -> {rel[:name], rel[:column]} end)
+
+    quote do
+      defmodule unquote(e[:json_encoder_module]) do
+        defimpl Jason.Encoder, for: unquote(e[:schema_module]) do
+          @attributes unquote(attributes)
+          @relations unquote(relations)
+
+          def encode(item, opts) do
+            item
+            |> Map.take(@attributes)
+            |> with_relations(@relations, item)
+            |> Jason.encode!()
+          end
+
+          defp with_relations(dest, rels, source) do
+            Enum.reduce(rels, dest, fn {name, col}, d ->
+              v = with %Ecto.Association.NotLoaded{} <- Map.get(source, name), do: %{id: Map.get(source, col)}
+              Map.put(d, name, v)
+            end)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/graphism/openapi.ex
+++ b/lib/graphism/openapi.ex
@@ -1,0 +1,800 @@
+defmodule Graphism.Openapi do
+  @moduledoc "Generates a OpenApi Spec"
+
+  alias Graphism.{Entity, Route}
+
+  def module_name(opts) do
+    caller = Keyword.fetch!(opts, :caller)
+
+    Module.concat([caller.module, OpenApi])
+  end
+
+  def spec_module(schema, opts) do
+    module_name = module_name(opts)
+    openapi = openapi(schema)
+
+    quote do
+      defmodule unquote(module_name) do
+        @behaviour Plug
+        @json "application/json"
+        @openapi unquote(openapi)
+        import Plug.Conn
+
+        def init(opts), do: opts
+
+        def call(conn, _opts) do
+          conn
+          |> put_resp_content_type(@json)
+          |> send_resp(200, @openapi)
+        end
+      end
+    end
+  end
+
+  def redocui_module(_schema, opts) do
+    caller = Keyword.fetch!(opts, :caller)
+    module_name = Module.concat([caller.module, RedocUI])
+
+    quote do
+      defmodule unquote(module_name) do
+        @behaviour Plug
+        import Plug.Conn
+
+        @index_html """
+        <!doctype html>
+        <html>
+          <head>
+            <title>ReDoc</title
+            <meta charset="utf-8">
+            <meta name="viewport" content="width=device-width, initial-scale=1">
+            <link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet">
+          </head>
+          <body>
+            <redoc spec-url="<%= spec_url %>"></redoc>
+            <script src="https://cdn.jsdelivr.net/npm/redoc@latest/bundles/redoc.standalone.js"></script>
+          </body>
+        </html>
+        """
+
+        @impl true
+        def init(opts) do
+          [html: EEx.eval_string(@index_html, opts)]
+        end
+
+        @impl true
+        def call(conn, html: html) do
+          send_resp(conn, 200, html)
+        end
+      end
+    end
+  end
+
+  defp operation_id(e, action), do: Inflex.camelize("#{e[:name]}_#{action}", :lower)
+  defp aggregate_operation_id(e, action), do: Inflex.camelize("aggregate_#{e[:name]}_by_#{action}", :lower)
+
+  def join_fields(key), do: Enum.join(key[:fields], "_and_")
+
+  defp openapi(schema) do
+    %{
+      openapi: "3.0.0",
+      info: %{
+        version: "1.0.0",
+        title: "",
+        license: %{name: "MIT"}
+      },
+      servers: [
+        %{url: "http://localhost:4001/api", description: "Local"}
+      ],
+      paths: %{},
+      components: %{},
+      security: []
+    }
+    |> with_schemas(schema)
+    |> with_paths(schema)
+    |> with_security(schema)
+    |> Jason.encode!()
+  end
+
+  defp with_schemas(spec, schema) do
+    schemas =
+      Enum.reduce(schema, %{}, fn e, schemas ->
+        schemas
+        |> with_id_schema(e, schema)
+        |> with_view_schema(e, schema)
+        |> with_create_schema(e, schema)
+        |> with_update_schema(e, schema)
+        |> with_list_schema(e, schema)
+        |> with_custom_schemas(e, schema)
+      end)
+      |> with_aggregation_schema()
+      |> with_unit_schema()
+      |> with_error_schema()
+      |> with_errors_schema()
+      |> with_free_form_object_schema()
+
+    put_in(spec, [:components, :schemas], schemas)
+  end
+
+  defp with_id_schema(schemas, e, _schema) do
+    Map.put(schemas, id_schema(e), %{
+      type: :object,
+      required: [:id],
+      properties: %{
+        id: type(:id, nil, nil)
+      }
+    })
+  end
+
+  defp with_view_schema(schemas, e, schema) do
+    Map.put(schemas, view_schema(e), %{
+      type: :object,
+      required: e |> Entity.required_attributes() |> Entity.names(),
+      properties:
+        e
+        |> Entity.all_fields()
+        |> Enum.reject(fn f -> f[:kind] == :has_many end)
+        |> Enum.reduce(%{}, fn f, props ->
+          Map.put(props, f[:name], field_type(f, schema))
+        end)
+    })
+  end
+
+  defp with_create_schema(schemas, e, schema) do
+    Map.put(schemas, create_schema(e), %{
+      type: :object,
+      required: e |> Entity.required_fields() |> Enum.reject(fn f -> f[:name] == :id end) |> Entity.names(),
+      properties:
+        e
+        |> Entity.required_fields()
+        |> Enum.reject(fn f -> f[:kind] == :has_many end)
+        |> Enum.reject(fn f -> f[:name] == :id end)
+        |> Enum.map(fn f ->
+          case f[:kind] do
+            :belongs_to -> Keyword.put(f, :kind, :id)
+            _ -> f
+          end
+        end)
+        |> Enum.reduce(%{}, fn f, props ->
+          Map.put(props, f[:name], field_type(f, schema))
+        end)
+    })
+  end
+
+  defp with_update_schema(schemas, e, schema) do
+    Map.put(schemas, update_schema(e), %{
+      type: :object,
+      properties:
+        e
+        |> Entity.required_fields()
+        |> Enum.reject(fn f -> f[:kind] == :has_many end)
+        |> Enum.reject(fn f -> f[:name] == :id end)
+        |> Enum.map(fn f ->
+          case f[:kind] do
+            :belongs_to -> Keyword.put(f, :kind, :id)
+            _ -> f
+          end
+        end)
+        |> Enum.reduce(%{}, fn f, props ->
+          Map.put(props, f[:name], field_type(f, schema))
+        end)
+    })
+  end
+
+  defp with_list_schema(schemas, e, _schema) do
+    Map.put(schemas, e[:plural_camel_name], %{
+      type: :array,
+      items: %{
+        "$ref": "#/components/schemas/#{e[:camel_name]}"
+      }
+    })
+  end
+
+  defp with_custom_schemas(schemas, e, _schema) do
+    e
+    |> Entity.custom_mutations()
+    |> Enum.reduce(schemas, fn {action, opts}, schemas ->
+      action_name = identifier(action)
+      args = custom_action_args(opts)
+
+      Map.put(schemas, custom_schema(e, action_name), %{
+        type: :object,
+        required: args |> Enum.map(fn {name, _} -> name end) |> Enum.map(&identifier/1),
+        properties:
+          Enum.reduce(args, %{}, fn {name, kind}, props ->
+            Map.put(props, identifier(name), type(kind, nil, nil))
+          end)
+      })
+    end)
+  end
+
+  defp with_aggregation_schema(schemas) do
+    Map.put(schemas, :aggregation, %{
+      type: :object,
+      required: [:count],
+      properties: %{
+        count: %{type: :integer}
+      }
+    })
+  end
+
+  defp with_unit_schema(schemas) do
+    Map.put(schemas, :unit, %{
+      type: :object,
+      required: [],
+      properties: %{}
+    })
+  end
+
+  defp with_errors_schema(schemas) do
+    Map.put(schemas, :errors, %{
+      type: :object,
+      required: [:reason],
+      properties: %{
+        reason: %{
+          type: :array,
+          items: %{
+            "$ref": "#/components/schemas/error"
+          }
+        }
+      }
+    })
+  end
+
+  defp with_free_form_object_schema(schemas) do
+    Map.put(schemas, :freeFormObject, %{
+      type: :object,
+      additionalProperties: true
+    })
+  end
+
+  defp with_error_schema(schemas) do
+    Map.put(schemas, :error, %{
+      type: :object,
+      required: [:detail],
+      properties: %{
+        detail: %{type: :string},
+        field: %{type: :string}
+      }
+    })
+  end
+
+  defp with_paths(spec, schema) do
+    paths =
+      Enum.reduce(schema, %{}, fn e, paths ->
+        paths
+        |> Map.put(Route.for_item(e), item_paths(e))
+        |> Map.put(Route.for_collection(e), collection_paths(e))
+        |> Map.put(Route.for_aggregation(e), aggregation_path(e))
+        |> with_children_paths(e, schema)
+        |> with_non_unique_keys_paths(e, schema)
+        |> with_unique_keys_paths(e, schema)
+        |> with_custom_queries_paths(e, schema)
+        |> with_custom_actions_paths(e, schema)
+      end)
+
+    put_in(spec, [:paths], paths)
+  end
+
+  defp with_security(spec, _schema) do
+    bearer = %{
+      bearerAuth: %{
+        type: :http,
+        scheme: :bearer,
+        bearerFormat: :JWT
+      }
+    }
+
+    spec
+    |> put_in([:components, :securitySchemes], bearer)
+    |> put_in([:security], [%{bearerAuth: []}])
+  end
+
+  defp item_paths(e) do
+    %{}
+    |> maybe_with_read_path(e)
+    |> maybe_with_update_path(e)
+    |> maybe_with_delete_path(e)
+  end
+
+  defp collection_paths(e) do
+    %{}
+    |> maybe_with_list_path(e)
+    |> maybe_with_create_path(e)
+  end
+
+  defp aggregation_path(e) do
+    %{
+      get: %{
+        summary: "Aggregate a collection of #{e[:plural_camel_name]}",
+        operationId: "aggregate#{e[:plural]}",
+        tags: [e[:plural_camel_name]],
+        parameters: [],
+        responses: aggregation_responses(e)
+      }
+    }
+  end
+
+  defp with_children_paths(paths, e, schema) do
+    e
+    |> Entity.relations()
+    |> Enum.filter(fn rel -> rel[:kind] == :has_many end)
+    |> Enum.reduce(paths, fn rel, acc ->
+      route = Route.for_children(e, rel)
+      aggregation_route = Route.for_children_aggregation(e, rel)
+      target = Entity.find_entity!(schema, rel[:target])
+
+      acc
+      |> Map.put(route, %{
+        get: %{
+          summary: "List multiple #{target[:plural_camel_name]} by #{e[:camel_name]}",
+          operationId: "list#{target[:plural]}By#{e[:display_name]}",
+          tags: [target[:plural_camel_name]],
+          parameters:
+            []
+            |> with_id_parameter(e)
+            |> with_pagination_parameters(),
+          responses: responses(target, plural: true)
+        }
+      })
+      |> Map.put(aggregation_route, %{
+        get: %{
+          summary: "Aggregate multiple #{target[:plural_camel_name]} for a given #{e[:camel_name]}",
+          operationId: "aggregate#{target[:plural]}By#{e[:display_name]}",
+          tags: [target[:plural_camel_name]],
+          parameters: with_id_parameter([], e),
+          responses: aggregation_responses(e)
+        }
+      })
+    end)
+  end
+
+  defp with_non_unique_keys_paths(paths, e, _schema) do
+    e
+    |> Entity.non_unique_keys()
+    |> Enum.reduce(paths, fn key, paths ->
+      fields = Enum.join(key[:fields], " and ")
+      route = Route.for_key(e, key)
+      params = key_params(e, key)
+      aggregation_route = Route.for_key_aggregation(e, key)
+
+      paths
+      |> Map.put(route, %{
+        get: %{
+          summary: "List multiple #{e[:plural_camel_name]} by #{fields}",
+          operationId: "list#{e[:plural]}By#{Inflex.camelize(fields)}",
+          tags: [e[:plural_camel_name]],
+          parameters: with_pagination_parameters(params),
+          responses: responses(e, plural: true)
+        }
+      })
+      |> Map.put(aggregation_route, %{
+        get: %{
+          summary: "Aggregate multiple #{e[:plural_camel_name]} by #{fields}",
+          operationId: "aggregate#{e[:plural]}By#{Inflex.camelize(fields)}",
+          tags: [e[:plural_camel_name]],
+          parameters: params,
+          responses: aggregation_responses(e)
+        }
+      })
+    end)
+  end
+
+  defp with_unique_keys_paths(paths, e, _schema) do
+    e
+    |> Entity.unique_keys_and_attributes()
+    |> Enum.reduce(paths, fn key, paths ->
+      fields = Enum.join(key[:fields], " and ")
+      route = Route.for_key(e, key)
+      params = key_params(e, key)
+
+      Map.put(paths, route, %{
+        get: %{
+          summary: "Read a single #{e[:camel_name]} by #{fields}",
+          operationId: "read#{e[:camel_name]}By#{Inflex.camelize(fields)}",
+          tags: [e[:camel_name]],
+          parameters: params,
+          responses: responses(e)
+        }
+      })
+    end)
+  end
+
+  defp key_params(e, key) do
+    key[:fields]
+    |> Enum.reduce([], fn field, params ->
+      name = key_parameter_name(field, e)
+      kind = key_parameter_type(field, e)
+      description = key_parameter_description(field, e)
+
+      with_path_parameter(params, name, kind, true, description)
+    end)
+    |> Enum.reverse()
+  end
+
+  defp with_custom_queries_paths(paths, e, _schema) do
+    e
+    |> Entity.custom_queries()
+    |> Enum.filter(&Entity.produces_multiple_results?/1)
+    |> Enum.reduce(paths, fn {action, opts}, paths ->
+      args = custom_action_args(opts)
+      arg_names = Enum.map(args, fn {name, _} -> name end)
+
+      path = Route.for_action(e, action, arg_names)
+      aggregation_path = Route.for_action_aggregation(e, action, arg_names)
+      description = Keyword.fetch!(opts, :desc)
+
+      params =
+        args
+        |> Enum.reduce([], fn {name, kind}, params ->
+          description = "A value of type #{kind}"
+          with_path_parameter(params, name, kind, true, description)
+        end)
+        |> Enum.reverse()
+
+      paths
+      |> Map.put(path, %{
+        get: %{
+          summary: description,
+          operationId: operation_id(e, action),
+          tags: [e[:plural_camel_name]],
+          parameters:
+            params
+            |> with_pagination_parameters(),
+          responses: responses(e, plural: true)
+        }
+      })
+      |> Map.put(aggregation_path, %{
+        get: %{
+          summary: "Aggregate #{description}",
+          operationId: aggregate_operation_id(e, action),
+          tags: [e[:plural_camel_name]],
+          parameters: params,
+          responses: aggregation_responses(e)
+        }
+      })
+    end)
+  end
+
+  defp with_custom_actions_paths(paths, e, schema) do
+    e
+    |> Entity.custom_mutations()
+    |> Enum.reduce(paths, fn {action, opts}, paths ->
+      path = Route.for_action(e, action)
+      description = Keyword.fetch!(opts, :desc)
+      produces = Keyword.fetch!(opts, :produces)
+
+      {tag, responses} =
+        case produces do
+          :unit ->
+            {e[:plural_camel_name], responses()}
+
+          {:list, entity} ->
+            produces = Entity.find_entity!(schema, entity)
+            {produces[:plural_camel_name], responses(produces, plural: true)}
+
+          entity ->
+            produces = Entity.find_entity!(schema, entity)
+            {produces[:camel_name], responses(produces)}
+        end
+
+      Map.put(paths, path, %{
+        post: %{
+          summary: description,
+          operationId: operation_id(e, action),
+          tags: [tag],
+          parameters: [],
+          requestBody: %{
+            description: "Info required execute action #{description}",
+            required: true,
+            content: %{
+              application_json: %{
+                schema: %{
+                  "$ref": "#/components/schemas/#{custom_schema(e, action)}"
+                }
+              }
+            }
+          },
+          responses: responses
+        }
+      })
+    end)
+  end
+
+  defp custom_action_args(opts) do
+    Enum.map(opts[:args] || [], fn
+      {name, kind} -> {name, kind}
+      name -> {name, :kind}
+    end)
+  end
+
+  defp key_parameter_name(field, _e), do: identifier(field)
+
+  defp key_parameter_type(field, e) do
+    case Entity.attribute_or_relation(e, field) do
+      {:attribute, opts} -> opts[:kind]
+      {:relation, _} -> :id
+    end
+  end
+
+  defp key_parameter_description(field, e) do
+    case Entity.attribute_or_relation(e, field) do
+      {:attribute, _} -> "The #{identifier(field)} of a #{e[:camel_name]}"
+      {:relation, opts} -> "The id of a #{identifier(opts[:target])}"
+    end
+  end
+
+  defp maybe_with_read_path(paths, e) do
+    case Entity.find_action(e, :read) do
+      nil ->
+        paths
+
+      _action ->
+        Map.put(paths, :get, %{
+          summary: "Read a single #{e[:camel_name]}",
+          operationId: "read#{e[:display_name]}",
+          tags: [e[:plural_camel_name]],
+          parameters: with_id_parameter([], e),
+          responses: responses(e)
+        })
+    end
+  end
+
+  defp maybe_with_update_path(paths, e) do
+    case Entity.find_action(e, :update) do
+      nil ->
+        paths
+
+      _action ->
+        Map.put(paths, :put, %{
+          summary: "Update an existing #{e[:camel_name]}",
+          operationId: "update#{e[:display_name]}",
+          tags: [e[:plural_camel_name]],
+          parameters: with_id_parameter([], e),
+          requestBody: %{
+            description: "Info required to update an existing #{e[:camel_name]}",
+            required: true,
+            content: %{
+              application_json: %{
+                schema: %{
+                  "$ref": "#/components/schemas/#{update_schema(e)}"
+                }
+              }
+            }
+          },
+          responses: responses(e)
+        })
+    end
+  end
+
+  defp update_schema(e), do: "#{e[:camel_name]}Update"
+
+  defp maybe_with_delete_path(paths, e) do
+    case Entity.find_action(e, :delete) do
+      nil ->
+        paths
+
+      _action ->
+        Map.put(paths, :delete, %{
+          summary: "Delete an existing #{e[:camel_name]}",
+          operationId: "delete#{e[:display_name]}",
+          tags: [e[:plural_camel_name]],
+          parameters: with_id_parameter([], e),
+          responses: responses()
+        })
+    end
+  end
+
+  defp maybe_with_list_path(paths, e) do
+    case Entity.find_action(e, :list) do
+      nil ->
+        paths
+
+      _action ->
+        Map.put(paths, :get, %{
+          summary: "List multiple #{e[:plural_camel_name]}",
+          operationId: "list#{e[:display_name]}",
+          tags: [e[:plural_camel_name]],
+          parameters: with_pagination_parameters([]),
+          responses: responses(e, plural: true)
+        })
+    end
+  end
+
+  defp maybe_with_create_path(paths, e) do
+    case Entity.find_action(e, :create) do
+      nil ->
+        paths
+
+      _action ->
+        Map.put(paths, :post, %{
+          summary: "Create a new #{e[:camel_name]}",
+          operationId: "create#{e[:display_name]}",
+          tags: [e[:plural_camel_name]],
+          parameters: [],
+          requestBody: %{
+            description: "Info required to create a new #{e[:camel_name]}",
+            required: true,
+            content: %{
+              application_json: %{
+                schema: %{
+                  "$ref": "#/components/schemas/#{create_schema(e)}"
+                }
+              }
+            }
+          },
+          responses: responses(e, success_status: 201, plural: true)
+        })
+    end
+  end
+
+  defp create_schema(e), do: custom_schema(e, "Create")
+  defp custom_schema(e, action), do: "#{e[:camel_name]}#{Inflex.camelize(action)}"
+
+  defp with_pagination_parameters(params) do
+    params
+    |> with_query_parameter(:limit, :integer, false, "The number of items to return")
+    |> with_query_parameter(:offset, :integer, false, "The position where to start fetching items from")
+    |> with_query_parameter(:sort, :string, false, "The field to sort items by")
+    |> with_query_parameter(
+      :sort_direction,
+      :sort_direction,
+      false,
+      "Whether to sort items in ascending or descending order"
+    )
+  end
+
+  defp with_id_parameter(params, e) do
+    with_path_parameter(params, :id, :id, true, "The id of the #{e[:camel_name]}")
+  end
+
+  defp with_path_parameter(params, name, kind, required, desc) do
+    with_parameter(params, name: name, in: :path, kind: kind, required: required, description: desc)
+  end
+
+  defp with_query_parameter(params, name, kind, required, desc) do
+    with_parameter(params, name: name, in: :query, kind: kind, required: required, description: desc)
+  end
+
+  defp with_parameter(params, opts) do
+    name = opts |> Keyword.fetch!(:name) |> Inflex.camelize(:lower)
+    kind = Keyword.fetch!(opts, :kind)
+    where = Keyword.fetch!(opts, :in)
+    desc = Keyword.fetch!(opts, :description)
+    required = Keyword.get(opts, :required, true)
+
+    [
+      %{
+        name: name,
+        in: where,
+        required: required,
+        description: desc,
+        schema: type(kind, nil, nil)
+      }
+      | params
+    ]
+  end
+
+  defp responses do
+    error_responses()
+    |> Map.put(:"200", unit_response())
+  end
+
+  defp responses(e, opts \\ []) do
+    error_responses()
+    |> Map.put(opts[:success_status] || :"200", success_response(e, opts))
+  end
+
+  defp error_responses do
+    %{
+      "400": invalid_response(),
+      "401": unauthorized_response(),
+      "404": not_found_response(),
+      "409": conflict_response(),
+      "429": too_many_requests_response(),
+      "500": server_error_response()
+    }
+  end
+
+  defp success_response(e, opts) do
+    schema =
+      case opts[:plural] do
+        nil -> e[:camel_name]
+        true -> e[:plural_camel_name]
+      end
+
+    %{
+      description: "Successful operation",
+      content: %{
+        "application/json": %{
+          schema: %{
+            "$ref": "#/components/schemas/#{schema}"
+          }
+        }
+      }
+    }
+  end
+
+  defp unit_response do
+    %{
+      description: "Successful operation",
+      content: %{
+        "application/json": %{
+          schema: %{
+            "$ref": "#/components/schemas/unit"
+          }
+        }
+      }
+    }
+  end
+
+  defp aggregation_responses(e) do
+    %{
+      "200": aggregation_successful_response(e),
+      "429": too_many_requests_response(),
+      "500": server_error_response()
+    }
+  end
+
+  defp aggregation_successful_response(_e) do
+    %{
+      description: "Successful operation",
+      content: %{
+        "application/json": %{
+          schema: %{
+            "$ref": "#/components/schemas/aggregation"
+          }
+        }
+      }
+    }
+  end
+
+  defp not_found_response, do: error_response("Not found")
+  defp invalid_response, do: error_response("Invalid request")
+  defp unauthorized_response, do: error_response("Unauthorized")
+  defp conflict_response, do: error_response("Conflict")
+  defp too_many_requests_response, do: error_response("Too many requests")
+  defp server_error_response, do: error_response("Internal server error")
+
+  defp error_response(desc) do
+    %{
+      description: desc,
+      content: %{
+        "application/json": %{
+          schema: %{
+            "$ref": "#/components/schemas/errors"
+          }
+        }
+      }
+    }
+  end
+
+  defp field_type(field, schema), do: type(field[:kind], field, schema)
+
+  defp type(:integer, _field, _schema), do: %{type: :integer}
+  defp type(:float, _field, _schema), do: %{type: :number}
+  defp type(:boolean, _field, _schema), do: %{type: :boolean}
+  defp type(:id, _field, _schema), do: %{type: :string, format: :uuid}
+  defp type(:sort_direction, _field, _schema), do: %{type: :string, enum: [:asc, :desc]}
+
+  defp type(:belongs_to, field, schema) do
+    target = Entity.find_entity!(schema, field[:target])
+
+    %{
+      nullable: false,
+      oneOf: [
+        %{"$ref": "#/components/schemas/#{view_schema(target)}"},
+        %{"$ref": "#/components/schemas/#{id_schema(target)}"}
+      ]
+    }
+  end
+
+  defp type(:json, _, _), do: %{type: :object, "$ref": "#/components/schemas/freeFormObject"}
+
+  defp type(_, _field, _schema), do: %{type: :string}
+
+  defp identifier(name), do: Inflex.camelize(name, :lower)
+
+  defp id_schema(e), do: e |> view_schema() |> schema("Id")
+  defp view_schema(e), do: e |> Keyword.fetch!(:camel_name) |> to_string()
+  defp schema(name, suffix), do: "#{name}#{suffix}"
+end

--- a/lib/graphism/resolver.ex
+++ b/lib/graphism/resolver.ex
@@ -607,21 +607,14 @@ defmodule Graphism.Resolver do
               end
 
             rel[:opts][:from] != nil ->
-              [parent_rel, rel_name] =
-                case rel[:opts][:from] do
-                  [parent_rel, rel_name] -> [parent_rel, rel_name]
-                  parent_rel -> [parent_rel, rel[:name]]
-                end
+              [parent_rel_name, ancestor_rel_name] = Entity.computed_relation_path(rel)
 
-              relation = Entity.relation!(e, parent_rel)
-              target_entity = relation[:target]
-
-              target = Entity.find_entity!(schema, target_entity)
-              api_module = target[:api_module]
+              parent_rel = Entity.relation!(e, parent_rel_name)
+              api_module = Entity.find_entity!(schema, parent_rel[:target])[:api_module]
 
               quote do
                 unquote(Ast.var(rel)) <-
-                  unquote(api_module).relation(unquote(Ast.var(parent_rel)), unquote(rel_name))
+                  unquote(api_module).relation(unquote(Ast.var(parent_rel_name)), unquote(ancestor_rel_name))
               end
 
             rel[:opts][:from_context] != nil ->

--- a/lib/graphism/rest.ex
+++ b/lib/graphism/rest.ex
@@ -1,0 +1,1047 @@
+defmodule Graphism.Rest do
+  @moduledoc "Generates a REST api"
+
+  alias Graphism.{Ast, Entity, Openapi, Route}
+
+  def helper_modules(_schema, hooks, _opts) do
+    auth = Entity.hook(hooks, :allow, :default)
+
+    quote do
+      defmodule RouterHelper do
+        import Plug.Conn
+        @json "application/json"
+
+        def send_json(conn, body, status \\ 200) do
+          conn
+          |> put_resp_content_type(@json)
+          |> send_resp(status, Jason.encode!(body))
+        end
+
+        def send_error(conn, %Ecto.Changeset{errors: errors}) do
+          reason =
+            Enum.map(errors, fn {field, {message, _}} ->
+              %{field: field, detail: message}
+            end)
+
+          send_error(conn, reason)
+        end
+
+        def send_error(conn, reason) do
+          send_json(conn, %{reason: reason(reason)}, status(reason))
+        end
+
+        def cast_param(conn, name, kind, default \\ :invalid) do
+          value = conn.params[name]
+
+          cast(value, kind, default)
+        end
+
+        def lookup(conn, param, api, :required) do
+          with {:ok, id} <- cast_param(conn, param, :id) do
+            api.get_by_id(id)
+          end
+        end
+
+        def lookup(conn, param, api, :optional) do
+          lookup_or_default(conn, param, api, fn -> nil end)
+        end
+
+        def lookup(conn, param, api, {:relation, api2, item, rel}) do
+          lookup_or_default(conn, param, api, fn ->
+            api2.relation(item, rel)
+          end)
+        end
+
+        defp lookup_or_default(conn, param, api, default_fn) do
+          case conn.params[param] do
+            nil ->
+              {:ok, default_fn.()}
+
+            "" ->
+              {:ok, default_fn.()}
+
+            value ->
+              with {:ok, id} <- cast(value, :id) do
+                api.get_by_id(id)
+              end
+          end
+        end
+
+        def lookup_relation(api, entity, relation) do
+          entity
+          |> api.relation(relation)
+          |> maybe_error(:not_found)
+        end
+
+        def lookup_context(context, path) do
+          context
+          |> get_in(path)
+          |> maybe_error(:missing_context)
+        end
+
+        defp maybe_error(nil, reason), do: {:error, reason}
+        defp maybe_error(value, _), do: {:ok, value}
+
+        def with_pagination(conn) do
+          with {:ok, offset} <- cast_param(conn, "offset", :integer, 0),
+               {:ok, limit} <- cast_param(conn, "limit", :integer, 20),
+               {:ok, sort_by} <- cast_param(conn, "sort_by", :string, nil),
+               {:ok, sort_direction} <- cast_param(conn, "sort_direction", :string, "asc") do
+            {:ok,
+             conn
+             |> assign(:offset, offset)
+             |> assign(:limit, limit)
+             |> assign(:sort_by, sort_by)
+             |> assign(:sort_direction, sort_direction)}
+          end
+        end
+
+        def with_item(assigns, item) do
+          Map.put(assigns, assigns.graphism.entity, item)
+        end
+
+        def allowed?(assigns, args \\ nil) do
+          case unquote(auth).allow?(args, assigns) do
+            true -> :ok
+            false -> {:error, :unauthorized}
+          end
+        end
+
+        defp cast(nil, _, :invalid), do: {:error, :invalid}
+        defp cast(nil, _, :continue), do: {:error, :continue}
+        defp cast(nil, _, default), do: {:ok, default}
+        defp cast(v, kind, _), do: cast(v, kind)
+
+        defp cast(v, :id) do
+          with :error <- Ecto.UUID.cast(v) do
+            {:error, :invalid}
+          end
+        end
+
+        defp cast(v, :integer) do
+          case Integer.parse(v) do
+            {v, ""} -> {:ok, v}
+            :error -> {:error, :invalid}
+          end
+        end
+
+        defp cast(v, :string) when is_binary(v), do: {:ok, v}
+        defp cast(json, :json) when is_map(json), do: {:ok, json}
+
+        def as(result, arg, args \\ %{})
+        def as({:ok, v}, arg, args), do: {:ok, Map.put(args, arg, v)}
+        def as({:error, :continue}, _, args), do: {:ok, args}
+        def as({:error, _} = error, _, _), do: error
+
+        defp reason(r) when is_atom(r), do: r |> to_string() |> reason()
+        defp reason(r) when is_binary(r), do: [%{detail: r}]
+        defp reason(r) when is_list(r), do: r
+
+        defp status(:not_found), do: 404
+        defp status(:invalid), do: 400
+        defp status(:unauthorized), do: 401
+        defp status(:conflict), do: 409
+        defp status([%{detail: "has already been taken"}]), do: 409
+        defp status(_), do: 500
+      end
+    end
+  end
+
+  def router_module(schema, opts) do
+    caller = Keyword.fetch!(opts, :caller)
+
+    telemetry_event_prefix =
+      caller.module
+      |> to_string()
+      |> String.downcase()
+      |> String.replace("elixir", "")
+      |> String.replace("schema", "")
+      |> String.split(".")
+      |> Enum.filter(fn s -> String.length(s) > 0 end)
+      |> Enum.map(&String.to_atom/1)
+      |> Kernel.++([:router])
+
+    quote do
+      defmodule Router do
+        use Plug.Router
+        import RouterHelper
+
+        plug(:match)
+        plug(Plug.Telemetry, event_prefix: unquote(telemetry_event_prefix))
+
+        plug(Plug.Parsers,
+          parsers: [:urlencoded, :multipart, :json],
+          pass: ["*/*"],
+          json_decoder: Jason
+        )
+
+        plug(:dispatch)
+
+        unquote_splicing(routes(schema))
+
+        get("/openapi.json", to: unquote(Openapi.module_name(opts)))
+
+        match _ do
+          send_json(unquote(Ast.var(:conn)), %{reason: :no_route}, 404)
+        end
+      end
+    end
+  end
+
+  def handler_modules(schema, hooks, opts) do
+    opts = Keyword.merge(opts, schema: schema, hooks: hooks)
+
+    Enum.flat_map(schema, fn e ->
+      standard_actions_handler_modules(e, opts) ++
+        aggregation_handler_modules(e, opts) ++
+        list_children_handler_modules(e, opts) ++
+        list_by_non_unique_key_handler_modules(e, opts) ++
+        list_by_custom_queries_handler_modules(e, opts) ++
+        read_by_unique_key_modules(e, opts) ++
+        custom_actions_handler_modules(e, opts)
+    end)
+  end
+
+  defp standard_actions_handler_modules(e, opts) do
+    [
+      list_handler_module(e, opts),
+      read_handler_module(e, opts),
+      create_handler_module(e, opts),
+      update_handler_module(e, opts),
+      delete_handler_module(e, opts)
+    ]
+  end
+
+  defp aggregation_handler_modules(e, opts) do
+    [
+      aggregate_all_handler_module(e, opts)
+    ]
+  end
+
+  defp read_by_unique_key_modules(e, opts) do
+    e
+    |> Entity.unique_keys_and_attributes()
+    |> Enum.map(&read_by_unique_key_module(e, &1, opts))
+  end
+
+  defp list_children_handler_modules(e, opts) do
+    e
+    |> Entity.relations()
+    |> Enum.filter(fn rel -> rel[:kind] == :has_many end)
+    |> Enum.flat_map(fn rel ->
+      [
+        list_children_handler_module(e, rel, opts),
+        aggregate_children_handler_module(e, rel, opts)
+      ]
+    end)
+  end
+
+  defp list_by_non_unique_key_handler_modules(e, opts) do
+    e
+    |> Entity.non_unique_keys()
+    |> Enum.flat_map(fn key ->
+      [
+        list_by_non_unique_key_handler_module(e, key, opts),
+        aggregate_by_non_unique_key_handler_module(e, key, opts)
+      ]
+    end)
+  end
+
+  defp list_by_custom_queries_handler_modules(e, opts) do
+    e
+    |> Entity.custom_queries()
+    |> Enum.flat_map(fn {name, action_opts} ->
+      [
+        list_by_custom_query_handler_module(e, name, action_opts, opts),
+        aggregate_by_custom_query_handler_module(e, name, action_opts, opts)
+      ]
+    end)
+  end
+
+  defp custom_actions_handler_modules(e, opts) do
+    e
+    |> Entity.custom_mutations()
+    |> Enum.map(fn {name, action_opts} ->
+      custom_action_handler_module(e, name, action_opts, opts)
+    end)
+  end
+
+  defp list_handler_module(e, opts) do
+    body =
+      quote do
+        def handle(conn, _opts) do
+          with :ok <- allowed?(conn.assigns),
+               {:ok, conn} <- with_pagination(conn),
+               {:ok, items} <- unquote(e[:api_module]).list(conn.assigns) do
+            send_json(conn, items)
+          else
+            {:error, reason} ->
+              send_error(conn, reason)
+          end
+        end
+      end
+
+    handler_module(e, :list, body, opts)
+  end
+
+  defp aggregate_all_handler_module(e, opts) do
+    body =
+      quote do
+        def handle(conn, _opts) do
+          with :ok <- allowed?(conn.assigns),
+               {:ok, item} <- unquote(e[:api_module]).aggregate(conn.assigns) do
+            send_json(conn, item)
+          else
+            {:error, reason} ->
+              send_error(conn, reason)
+          end
+        end
+      end
+
+    handler_module(e, :aggregate, body, opts)
+  end
+
+  defp list_children_handler_module(e, rel, opts) do
+    schema = Keyword.fetch!(opts, :schema)
+    belongs_to = Entity.inverse_relation!(schema, e, rel[:name])
+    target = Entity.find_entity!(schema, rel[:target])
+    action = list_children_action(rel)
+    api_fun_name = Entity.list_by_parent_fun_name(belongs_to)
+
+    opts =
+      opts
+      |> Keyword.put(:auth_action, :list)
+      |> Keyword.put(:auth_entity, rel[:target])
+
+    body =
+      quote do
+        def handle(conn, _opts) do
+          with :ok <- allowed?(conn.assigns),
+               {:ok, id} <- cast_param(conn, "id", :id),
+               {:ok, _} <- unquote(e[:api_module]).get_by_id(id),
+               {:ok, conn} <- with_pagination(conn),
+               {:ok, items} <- unquote(target[:api_module]).unquote(api_fun_name)(id, conn.assigns) do
+            send_json(conn, items)
+          else
+            {:error, reason} ->
+              send_error(conn, reason)
+          end
+        end
+      end
+
+    handler_module(e, action, body, opts)
+  end
+
+  defp aggregate_children_handler_module(e, rel, opts) do
+    schema = Keyword.fetch!(opts, :schema)
+    belongs_to = Entity.inverse_relation!(schema, e, rel[:name])
+    target = Entity.find_entity!(schema, rel[:target])
+    action = aggregate_children_action(rel)
+    api_fun_name = Entity.aggregate_by_parent_fun_name(belongs_to)
+
+    opts =
+      opts
+      |> Keyword.put(:auth_action, :list)
+      |> Keyword.put(:auth_entity, rel[:target])
+
+    body =
+      quote do
+        def handle(conn, _opts) do
+          with :ok <- allowed?(conn.assigns),
+               {:ok, id} <- cast_param(conn, "id", :id),
+               {:ok, _} <- unquote(e[:api_module]).get_by_id(id),
+               {:ok, result} <- unquote(target[:api_module]).unquote(api_fun_name)(id, conn.assigns) do
+            send_json(conn, result)
+          else
+            {:error, reason} ->
+              send_error(conn, reason)
+          end
+        end
+      end
+
+    handler_module(e, action, body, opts)
+  end
+
+  defp list_by_non_unique_key_handler_module(e, key, opts) do
+    action = list_by_non_unique_key_action(key)
+    api_fun_name = Entity.list_by_key_fun_name(key)
+
+    opts =
+      opts
+      |> Keyword.put(:auth_action, :list)
+      |> Keyword.put(:auth_entity, e[:name])
+
+    field_var_names = Ast.vars(key[:fields])
+    field_vars = cast_key_values_from_conn(key, e)
+
+    body =
+      quote do
+        def handle(conn, _opts) do
+          with :ok <- allowed?(conn.assigns),
+               unquote_splicing(field_vars),
+               {:ok, conn} <- with_pagination(conn),
+               {:ok, items} <-
+                 unquote(e[:api_module]).unquote(api_fun_name)(unquote_splicing(field_var_names), conn.assigns) do
+            send_json(conn, items)
+          else
+            {:error, reason} ->
+              send_error(conn, reason)
+          end
+        end
+      end
+
+    handler_module(e, action, body, opts)
+  end
+
+  defp aggregate_by_non_unique_key_handler_module(e, key, opts) do
+    action = aggregate_by_non_unique_key_action(key)
+    api_fun_name = Entity.aggregate_by_key_fun_name(key)
+
+    opts =
+      opts
+      |> Keyword.put(:auth_action, :list)
+      |> Keyword.put(:auth_entity, e[:name])
+
+    field_var_names = Ast.vars(key[:fields])
+    field_vars = cast_key_values_from_conn(key, e)
+
+    body =
+      quote do
+        def handle(conn, _opts) do
+          with :ok <- allowed?(conn.assigns),
+               unquote_splicing(field_vars),
+               {:ok, result} <-
+                 unquote(e[:api_module]).unquote(api_fun_name)(unquote_splicing(field_var_names), conn.assigns) do
+            send_json(conn, result)
+          else
+            {:error, reason} ->
+              send_error(conn, reason)
+          end
+        end
+      end
+
+    handler_module(e, action, body, opts)
+  end
+
+  defp list_by_custom_query_handler_module(e, action, action_opts, opts) do
+    {args_vars, args} = custom_action_args(e, action_opts, opts)
+
+    body =
+      quote do
+        def handle(conn, _opts) do
+          with :ok <- allowed?(conn.assigns),
+               unquote_splicing(args_vars),
+               args <- %{},
+               unquote_splicing(args),
+               {:ok, conn} <- with_pagination(conn),
+               {:ok, items} <-
+                 unquote(e[:api_module]).unquote(action)(args, conn.assigns) do
+            send_json(conn, items)
+          else
+            {:error, reason} ->
+              send_error(conn, reason)
+          end
+        end
+      end
+
+    handler_module(e, action, body, opts)
+  end
+
+  defp aggregate_by_custom_query_handler_module(e, action, action_opts, opts) do
+    opts = Keyword.put(opts, :auth_action, action)
+    action = aggregate_by_custom_query_action(action)
+
+    {args_vars, args} = custom_action_args(e, action_opts, opts)
+
+    body =
+      quote do
+        def handle(conn, _opts) do
+          with :ok <- allowed?(conn.assigns),
+               unquote_splicing(args_vars),
+               args <- %{},
+               unquote_splicing(args),
+               {:ok, result} <-
+                 unquote(e[:api_module]).unquote(action)(args, conn.assigns) do
+            send_json(conn, result)
+          else
+            {:error, reason} ->
+              send_error(conn, reason)
+          end
+        end
+      end
+
+    handler_module(e, action, body, opts)
+  end
+
+  defp cast_key_values_from_conn(key, e) do
+    key[:fields]
+    |> Enum.map(fn f ->
+      case Entity.attribute_or_relation(e, f) do
+        {:attribute, attr} -> {f, attr[:kind]}
+        {:relation, _} -> {f, :id}
+      end
+    end)
+    |> Enum.map(fn {name, kind} ->
+      quote do
+        {:ok, unquote(Ast.var(name))} <- cast_param(conn, unquote(to_string(name)), unquote(kind))
+      end
+    end)
+  end
+
+  defp read_handler_module(e, opts) do
+    body =
+      quote do
+        def handle(conn, _opts) do
+          with {:ok, item} <- lookup(conn, "id", unquote(e[:api_module]), :required),
+               :ok <- conn.assigns |> with_item(item) |> allowed?() do
+            send_json(conn, item)
+          else
+            {:error, reason} ->
+              send_error(conn, reason)
+          end
+        end
+      end
+
+    handler_module(e, :read, body, opts)
+  end
+
+  defp read_by_unique_key_module(e, key, opts) do
+    action = read_by_unique_key_action(key)
+    api_fun = Graphism.Entity.get_by_key_fun_name(key)
+
+    vars = Enum.map(key[:fields], fn f -> Ast.var(f) end)
+
+    cast_params =
+      Enum.map(key[:fields], fn f ->
+        param = to_string(f)
+
+        kind =
+          case Entity.attribute_or_relation(e, f) do
+            {:attribute, attr} -> attr[:kind]
+            {:relation, _} -> :id
+          end
+
+        quote do
+          {:ok, unquote(Ast.var(f))} <- cast_param(conn, unquote(param), unquote(kind))
+        end
+      end)
+
+    body =
+      quote do
+        def handle(conn, _opts) do
+          with unquote_splicing(cast_params),
+               {:ok, item} <- unquote(e[:api_module]).unquote(api_fun)(unquote_splicing(vars)),
+               :ok <- conn.assigns |> with_item(item) |> allowed?() do
+            send_json(conn, item)
+          else
+            {:error, reason} ->
+              send_error(conn, reason)
+          end
+        end
+      end
+
+    opts = Keyword.put(opts, :auth_action, :read)
+
+    handler_module(e, action, body, opts)
+  end
+
+  defp handler_id_arg(e, _opts) do
+    case Entity.client_ids?(e) do
+      true ->
+        quote do
+          {:ok, args} <- conn |> cast_param("id", :id) |> as(:id)
+        end
+
+      false ->
+        quote do
+          args <- %{id: Ecto.UUID.generate()}
+        end
+    end
+  end
+
+  defp handler_attribute_args(e, opts) do
+    e[:attributes]
+    |> Enum.reject(&Entity.id?/1)
+    |> Enum.reject(&Entity.computed?/1)
+    |> Enum.map(&handler_attribute_cast_param(&1, opts))
+  end
+
+  defp handler_attribute_cast_param(attr, opts) do
+    name = attr[:name]
+    kind = attr[:kind]
+    mode = Keyword.get(opts, :mode, :create)
+
+    default =
+      case {mode, Entity.optional?(attr)} do
+        {:create, true} -> nil
+        {:create, false} -> :invalid
+        {:update, true} -> nil
+        {:update, false} -> :continue
+      end
+
+    quote do
+      {:ok, args} <-
+        conn |> cast_param(unquote(to_string(name)), unquote(kind), unquote(default)) |> as(unquote(name), args)
+    end
+  end
+
+  defp handler_parent_arg_vars(e) do
+    e |> Entity.parent_relations() |> Entity.names() |> Ast.vars()
+  end
+
+  defp handler_parent_args(e, opts) do
+    handler_non_computed_parent_args(e, opts) ++
+      handler_computed_parent_args(e, opts)
+  end
+
+  defp handler_non_computed_parent_args(e, opts) do
+    schema = Keyword.fetch!(opts, :schema)
+    mode = Keyword.get(opts, :mode, :create)
+
+    e
+    |> Entity.parent_relations()
+    |> Enum.reject(&Entity.computed?/1)
+    |> Enum.map(fn rel ->
+      name = rel[:name]
+      target = Entity.find_entity!(schema, rel[:target])
+
+      case mode do
+        :create ->
+          default = if Entity.optional?(rel), do: :optional, else: :invalid
+
+          quote do
+            {:ok, unquote(Ast.var(name))} <-
+              lookup(conn, unquote(to_string(name)), unquote(target[:api_module]), unquote(default))
+          end
+
+        :update ->
+          quote do
+            {:ok, unquote(Ast.var(name))} <-
+              lookup(
+                conn,
+                unquote(to_string(name)),
+                unquote(target[:api_module]),
+                {:relation, unquote(e[:api_module]), unquote(Ast.var(e)), unquote(name)}
+              )
+          end
+      end
+    end)
+  end
+
+  defp handler_computed_parent_args(e, opts) do
+    handler_computed_parents_from_context_args(e, opts) ++
+      handler_computed_ancestor_args(e, opts) ++
+      handler_computed_parents_using_hook_args(e, opts)
+  end
+
+  defp handler_computed_ancestor_args(e, opts) do
+    schema = Keyword.fetch!(opts, :schema)
+
+    e
+    |> Entity.parent_relations()
+    |> Enum.filter(&Entity.computed?/1)
+    |> Enum.filter(&Entity.ancestor?/1)
+    |> Enum.map(fn rel ->
+      name = rel[:name]
+
+      [parent_rel_name, ancestor_rel_name] = Entity.computed_relation_path(rel)
+
+      parent_rel = Entity.relation!(e, parent_rel_name)
+      api_module = Entity.find_entity!(schema, parent_rel[:target])[:api_module]
+
+      quote do
+        {:ok, unquote(Ast.var(name))} <-
+          lookup_relation(unquote(api_module), unquote(Ast.var(parent_rel_name)), unquote(ancestor_rel_name))
+      end
+    end)
+  end
+
+  defp handler_computed_parents_from_context_args(e, _opts) do
+    e
+    |> Entity.parent_relations()
+    |> Enum.filter(fn rel -> rel[:opts][:from_context] end)
+    |> Enum.map(fn rel ->
+      name = rel[:name]
+      from = rel[:opts][:from_context]
+
+      quote do
+        {:ok, unquote(Ast.var(name))} <- lookup_context(conn.assigns, unquote(from))
+      end
+    end)
+  end
+
+  defp handler_computed_parents_using_hook_args(e, _opts) do
+    e
+    |> Entity.parent_relations()
+    |> Enum.filter(fn rel -> rel[:opts][:using] end)
+    |> Enum.map(fn rel ->
+      name = rel[:name]
+      mod = rel[:opts][:using]
+
+      quote do
+        {:ok, unquote(Ast.var(name))} <- unquote(mod).execute(conn.assigns)
+      end
+    end)
+  end
+
+  defp create_handler_module(e, opts) do
+    args = handler_attribute_args(e, opts) ++ handler_parent_args(e, opts)
+    args = [handler_id_arg(e, opts) | args]
+
+    body =
+      quote do
+        def handle(conn, _opts) do
+          with unquote_splicing(args),
+               :ok <- allowed?(conn.assigns, args),
+               {:ok, item} <-
+                 unquote(e[:api_module]).create(unquote_splicing(handler_parent_arg_vars(e)), args) do
+            send_json(conn, item, 201)
+          else
+            {:error, reason} ->
+              send_error(conn, reason)
+          end
+        end
+      end
+
+    handler_module(e, :create, body, opts)
+  end
+
+  defp update_handler_module(e, opts) do
+    opts = Keyword.put(opts, :mode, :update)
+    args = handler_attribute_args(e, opts) ++ handler_parent_args(e, opts)
+
+    body =
+      quote do
+        def handle(conn, _opts) do
+          with {:ok, unquote(Ast.var(e))} <- lookup(conn, "id", unquote(e[:api_module]), :required),
+               args <- %{},
+               unquote_splicing(args),
+               :ok <- conn.assigns |> with_item(unquote(Ast.var(e))) |> allowed?(args),
+               {:ok, unquote(Ast.var(e))} <-
+                 unquote(e[:api_module]).update(unquote_splicing(handler_parent_arg_vars(e)), unquote(Ast.var(e)), args) do
+            send_json(conn, unquote(Ast.var(e)))
+          else
+            {:error, reason} ->
+              send_error(conn, reason)
+          end
+        end
+      end
+
+    handler_module(e, :update, body, opts)
+  end
+
+  defp delete_handler_module(e, opts) do
+    body =
+      quote do
+        def handle(conn, _opts) do
+          with {:ok, id} <- cast_param(conn, "id", :id),
+               {:ok, item} <- unquote(e[:api_module]).get_by_id(id),
+               :ok <- conn.assigns |> with_item(item) |> allowed?(),
+               {:ok, _} <- unquote(e[:api_module]).delete(item) do
+            send_json(conn, %{})
+          else
+            {:error, reason} ->
+              send_error(conn, reason)
+          end
+        end
+      end
+
+    handler_module(e, :delete, body, opts)
+  end
+
+  defp custom_action_handler_module(e, action, action_opts, opts) do
+    {args_vars, args} = custom_action_args(e, action_opts, opts)
+
+    body =
+      quote do
+        def handle(conn, _opts) do
+          with :ok <- allowed?(conn.assigns),
+               unquote_splicing(args_vars),
+               args <- %{},
+               unquote_splicing(args),
+               {:ok, result} <-
+                 unquote(e[:api_module]).unquote(action)(args, conn.assigns) do
+            send_json(conn, result)
+          else
+            {:error, reason} ->
+              send_error(conn, reason)
+          end
+        end
+      end
+
+    handler_module(e, action, body, opts)
+  end
+
+  defp custom_action_args(e, action_opts, opts) do
+    schema = Keyword.fetch!(opts, :schema)
+
+    args = normalize_custom_action_args(e, action_opts)
+    arg_names = arg_names(args)
+
+    vars =
+      Enum.flat_map(args, fn
+        {name, kind, []} ->
+          [
+            quote do
+              {:ok, unquote(Ast.var(name))} <- cast_param(conn, unquote(to_string(name)), unquote(kind))
+            end
+          ]
+
+        {name, kind, rel: rel} ->
+          target = Entity.find_entity!(schema, rel[:target])
+
+          [
+            quote do
+              {:ok, unquote(Ast.var(name))} <- cast_param(conn, unquote(to_string(name)), unquote(kind))
+            end,
+            quote do
+              {:ok, unquote(Ast.var(name))} <- unquote(target[:api_module]).get_by_id(unquote(Ast.var(name)))
+            end
+          ]
+      end)
+
+    args =
+      Enum.map(arg_names, fn name ->
+        quote do
+          args <- Map.put(args, unquote(name), unquote(Ast.var(name)))
+        end
+      end)
+
+    {vars, args}
+  end
+
+  defp handler_module(e, action, body, opts) do
+    handler = handler(action, e)
+    auth_action = opts[:auth_action] || action
+    auth_entity = opts[:auth_entity] || e[:name]
+    body = if is_list(body), do: body, else: [body]
+
+    quote do
+      defmodule unquote(handler) do
+        use Plug.Builder
+        import RouterHelper
+
+        plug(:auth_context)
+        plug(:handle)
+
+        def auth_context(conn, _opts) do
+          assign(conn, :graphism, %{action: unquote(auth_action), entity: unquote(auth_entity)})
+        end
+
+        unquote_splicing(body)
+      end
+    end
+  end
+
+  defp routes(schema), do: Enum.flat_map(schema, fn e -> entity_routes(e, schema) end)
+
+  defp entity_routes(e, schema) do
+    [
+      aggregation_routes(e) ++
+        standard_routes(e) ++
+        list_children_routes(e, schema) ++
+        list_by_non_unique_key_routes(e) ++
+        list_by_custom_query_routes(e) ++
+        read_by_unique_key_routes(e) ++
+        custom_action_routes(e)
+    ]
+    |> List.flatten()
+    |> Enum.reject(&is_nil/1)
+  end
+
+  defp standard_routes(e) do
+    Enum.map(e[:actions], fn {action, _opts} ->
+      method = method(action)
+      path = path(action, e)
+      handler = handler(action, e)
+
+      quote do
+        unquote(method)(unquote(path), to: unquote(handler))
+      end
+    end)
+  end
+
+  defp aggregation_routes(e) do
+    [maybe_aggregate_all_route(e)]
+  end
+
+  defp list_children_routes(e, schema) do
+    e
+    |> Entity.relations()
+    |> Enum.filter(fn rel -> rel[:kind] == :has_many end)
+    |> Enum.flat_map(fn rel ->
+      target = Entity.find_entity!(schema, rel[:target])
+
+      if Entity.action?(target, :list) do
+        path = Route.for_children(e, rel)
+        aggregation_path = Route.for_children_aggregation(e, rel)
+        handler = rel |> list_children_action() |> handler(e)
+        aggregation_handler = rel |> aggregate_children_action() |> handler(e)
+
+        [
+          quote do
+            get(unquote(path), to: unquote(handler))
+          end,
+          quote do
+            get(unquote(aggregation_path), to: unquote(aggregation_handler))
+          end
+        ]
+      else
+        []
+      end
+    end)
+  end
+
+  defp list_by_non_unique_key_routes(e) do
+    if Entity.action?(e, :list) do
+      e
+      |> Entity.non_unique_keys()
+      |> Enum.flat_map(fn key ->
+        path = Route.for_key(e, key)
+        handler = key |> list_by_non_unique_key_action() |> handler(e)
+        aggregation_path = Route.for_key_aggregation(e, key)
+        aggregation_handler = key |> aggregate_by_non_unique_key_action() |> handler(e)
+
+        [
+          quote do
+            get(unquote(path), to: unquote(handler))
+          end,
+          quote do
+            get(unquote(aggregation_path), to: unquote(aggregation_handler))
+          end
+        ]
+      end)
+    else
+      []
+    end
+  end
+
+  defp list_by_custom_query_routes(e) do
+    e
+    |> Entity.custom_queries()
+    |> Enum.flat_map(fn {action, opts} ->
+      args = Enum.map(opts[:args] || [], fn {name, _} -> name end)
+      path = Route.for_action(e, action, args)
+      handler = handler(action, e)
+      aggregation_path = Route.for_action_aggregation(e, action, args)
+      aggregation_handler = action |> aggregate_by_custom_query_action() |> handler(e)
+
+      [
+        quote do
+          get(unquote(path), to: unquote(handler))
+        end,
+        quote do
+          get(unquote(aggregation_path), to: unquote(aggregation_handler))
+        end
+      ]
+    end)
+  end
+
+  defp read_by_unique_key_routes(e) do
+    if Entity.action?(e, :read) do
+      e
+      |> Entity.unique_keys_and_attributes()
+      |> Enum.map(fn key ->
+        path = Route.for_key(e, key)
+        handler = key |> read_by_unique_key_action() |> handler(e)
+
+        quote do
+          get(unquote(path), to: unquote(handler))
+        end
+      end)
+    else
+      []
+    end
+  end
+
+  defp maybe_aggregate_all_route(e) do
+    if Entity.action?(e, :list) do
+      path = Route.for_aggregation(e)
+      handler = handler(:aggregate, e)
+
+      quote do
+        get(unquote(path), to: unquote(handler))
+      end
+    else
+      nil
+    end
+  end
+
+  defp custom_action_routes(e) do
+    e
+    |> Entity.custom_mutations()
+    |> Enum.map(fn {name, _opts} ->
+      path = Route.for_action(e, name)
+      handler = handler(name, e)
+
+      quote do
+        post(unquote(path), to: unquote(handler))
+      end
+    end)
+  end
+
+  defp normalize_custom_action_args(e, opts) do
+    Enum.map(opts[:args] || [], fn
+      {name, kind} ->
+        {name, kind, []}
+
+      name ->
+        case Entity.attribute_or_relation(e, name) do
+          {:attribute, attr} -> {name, attr[:kind], []}
+          {:relation, rel} -> {name, :id, rel: rel}
+        end
+    end)
+  end
+
+  defp arg_names(args) do
+    Enum.map(args, fn {name, _, _} -> name end)
+  end
+
+  defp method(:read), do: :get
+  defp method(:list), do: :get
+  defp method(:create), do: :post
+  defp method(:update), do: :put
+  defp method(:delete), do: :delete
+
+  defp path(:read, e), do: Route.for_item(e)
+  defp path(:list, e), do: Route.for_collection(e)
+  defp path(:create, e), do: Route.for_collection(e)
+  defp path(:update, e), do: Route.for_item(e)
+  defp path(:delete, e), do: Route.for_item(e)
+
+  defp handler(action, e) do
+    Module.concat([e[:handler_module], Inflex.camelize(action)])
+  end
+
+  def join_fields(key), do: Enum.join(key[:fields], "_and_")
+
+  defp read_by_unique_key_action(key) do
+    fields = join_fields(key)
+
+    String.to_atom("read_by_#{fields}")
+  end
+
+  defp list_children_action(rel) do
+    String.to_atom("list_#{rel[:name]}")
+  end
+
+  defp aggregate_children_action(rel) do
+    String.to_atom("aggregate_#{rel[:name]}")
+  end
+
+  defp list_by_non_unique_key_action(key) do
+    fields = join_fields(key)
+
+    String.to_atom("list_by_#{fields}")
+  end
+
+  defp aggregate_by_non_unique_key_action(key) do
+    fields = join_fields(key)
+
+    String.to_atom("aggregate_by_#{fields}")
+  end
+
+  defp aggregate_by_custom_query_action(name) do
+    String.to_atom("aggregate_#{name}")
+  end
+end

--- a/lib/graphism/route.ex
+++ b/lib/graphism/route.ex
@@ -1,0 +1,54 @@
+defmodule Graphism.Route do
+  @moduledoc "Conventions around http routes"
+
+  def for_item(e), do: e |> for_collection() |> with_param("id") |> route()
+  def for_collection(e), do: route("/#{e[:plural]}")
+  def for_aggregation(e), do: e |> for_collection() |> aggregated() |> route()
+  def for_children(e, rel), do: e |> for_item() |> suffixed_with(rel[:name]) |> route()
+  def for_children_aggregation(e, rel), do: e |> for_children(rel) |> aggregated() |> route()
+
+  def for_action(e, action, params \\ []) do
+    base = e |> for_collection() |> suffixed_with(action)
+
+    Enum.reduce(params, base, fn param, path ->
+      path
+      |> suffixed_with(param)
+      |> with_param(param)
+    end)
+    |> route()
+  end
+
+  def for_action_aggregation(e, action, params \\ []) do
+    e
+    |> for_action(action, params)
+    |> aggregated()
+  end
+
+  def for_key(e, key) do
+    key[:fields]
+    |> Enum.reduce(for_aggregation(e), fn field, path ->
+      path
+      |> suffixed_with(field)
+      |> with_param(field)
+    end)
+    |> route()
+  end
+
+  def for_key_aggregation(e, key) do
+    e
+    |> for_key(key)
+    |> aggregated()
+  end
+
+  defp suffixed_with(path, suffix), do: "#{path}/#{suffix}"
+  defp with_param(path, param), do: suffixed_with(path, ":#{param}")
+  defp aggregated(path), do: suffixed_with(path, "aggregation")
+
+  defp route(path) do
+    path
+    |> String.split("/")
+    |> Enum.map(&Inflex.camelize/1)
+    |> Enum.join("/")
+    |> String.downcase()
+  end
+end


### PR DESCRIPTION
### Description

Adds a REST api to a Graphism Schema

Tasks:

- [x] OpenAPI spec
  - [x] Error codes 
  - [x] Read by ID
  - [x] Read by unique attribute
  - [x] Read by unique keys
  - [x] List
  - [x] List aggregations
  - [x] List by parent
  - [x] List by parent aggregations
  - [x] List and aggregations by non unique keys
  - [x] List and aggregations by custom queries
  - [x] Create
  - [x] Update
  - [x] Delete
  - [x] Custom actions
  - [x] Authorisation scheme
  - [x] Generate a TS client (`openapi-generator-cli generate -g typescript -i http://localhost:4001/api/openapi.json -o client`)
- [x] Rest API
  - [x] Error codes 
  - [x] Read by ID
  - [x] Read by unique attribute
  - [x] Read by unique keys 
  - [x] List
  - [x] List aggregations
  - [x] List by parent
  - [x] List by parent aggregations
  - [x] List and aggregations by non unique keys
  - [x] List and aggregations by custom queries
  - [x] Create
  - [x] Update
  - [x] Delete
  - [x] Custom actions
  - [x] Authorisation scheme

Leftovers:

- [x] Add column_id for non-preloaded `:belongs_to` associations in openapi schema
- [x] Do not return private fields in responses
- [x] Decide if we should return all fields as camelCase.
- [x] Openapi DELETE should return a 200 + empty object
- [x] Make case consistent with urls
- [x] Better AST in router module
- [x] Split openapi and rest into separate modules
- [x] GraphQL and REST styles opt-in via a flag. Also add it to the generator mix archive
- [x] Telemetry
- [ ] ~~Pluggable Middleware~~
- [x] Support for `from_context` relations in create/update
- [x] Support for `:using`  in create/update
- [x] Support for optional relations in create/update
- [x] Encode Ecto changes errors as json
- [ ] ~~Inline creation of children entities~~
- [x] Document 409s in openapi spec
- [ ] ~~Decide whether to apply auth to every item in a list, and to every field on an item.~~
- [x] Use `conn.assigns` as context root
- [x] Resolve custom action args that are relations
- [x] Custom actions should receive args via request body rather than params
- [x] Support for json types
 
### Checklist

- [ ] Added or modified tests 
- [x] Added an entry to the CHANGELOG
