### PR TITLE
Better support for aliases in computed relations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-* Ast improvements [#117](https://github.com/Gravity-Core/graphism/pull/117)
+* Better support for aliases in computed relations - [#118](https://github.com/Gravity-Core/graphism/pull/118)
+* Ast improvements - [#117](https://github.com/Gravity-Core/graphism/pull/117)
 
 ## 0.7.2 (July 20th, 2022)
 

--- a/lib/graphism/resolver.ex
+++ b/lib/graphism/resolver.ex
@@ -607,10 +607,21 @@ defmodule Graphism.Resolver do
               end
 
             rel[:opts][:from] != nil ->
-              from = rel[:opts][:from]
+              [parent_rel, rel_name] =
+                case rel[:opts][:from] do
+                  [parent_rel, rel_name] -> [parent_rel, rel_name]
+                  parent_rel -> [parent_rel, rel[:name]]
+                end
+
+              relation = Entity.relation!(e, parent_rel)
+              target_entity = relation[:target]
+
+              target = Entity.find_entity!(schema, target_entity)
+              api_module = target[:api_module]
 
               quote do
-                unquote(Ast.var(rel)) <- unquote(api_module).relation(unquote(Ast.var(from)), unquote(rel[:name]))
+                unquote(Ast.var(rel)) <-
+                  unquote(api_module).relation(unquote(Ast.var(parent_rel)), unquote(rel_name))
               end
 
             rel[:opts][:from_context] != nil ->


### PR DESCRIPTION
### Description

Better support for aliases in computed relations. 

Eg:

```elixir
entity :blog do
  ... 
   belongs_to(:user, as: :owner)
  ...
end

entity :post do
  ...
  belongs_to(:blog, as: :parent)
  belongs_to(:user, as: :author, from: [:parent, :owner])
  ...
end
```

### Checklist

- [ ] Added or modified tests 
- [x] Added an entry to the CHANGELOG
