### PR TITLE
Cache relations properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Drop tables after indices - [#130](https://github.com/Gravity-Core/graphism/pull/130)
 * List arguments in custom actions - [#128](https://github.com/Gravity-Core/graphism/pull/128)
 * New dataloader, querying, evaluate and compare apis - [#127](https://github.com/Gravity-Core/graphism/pull/127)
+* Cache relations properly - [#132](https://github.com/Gravity-Core/graphism/pull/132)
 
 ## 0.8.3 (September 6th, 2022)
 
@@ -40,7 +41,7 @@
 
 ## 0.7.0 (July 19th, 2022)
 
-* Split code into smaller modules - [#111](https://github.com/Gravity-Core/graphism/pull/111) 
+* Split code into smaller modules - [#111](https://github.com/Gravity-Core/graphism/pull/111)
 * Fix index creation order - [#110](https://github.com/Gravity-Core/graphism/pull/110)
 * Custom aggregations - [#109](https://github.com/Gravity-Core/graphism/pull/109)
 * Relation telemetry - [#108](https://github.com/Gravity-Core/graphism/pull/108)

--- a/lib/graphism/querying.ex
+++ b/lib/graphism/querying.ex
@@ -296,10 +296,10 @@ defmodule Graphism.Querying do
         end
       end
 
-      defp relation(%{__struct__: schema} = context, field) do
+      defp relation(%{__struct__: schema, id: id} = context, field) do
         with rel when rel != nil <- Map.get(context, field) do
           if unloaded?(rel) do
-            key = {schema.entity(), field}
+            key = {id, field}
 
             with nil <- Process.get(key) do
               rel = context |> unquote(repo).preload(field) |> Map.get(field)


### PR DESCRIPTION
### Description

Fixes the way relations are cache, when evaluating dot expressions. Rather than caching by entity/relation, we should be caching by id/relation, otherwise undesired side effects are to be expected!

### Checklist

- [ ] Added or modified tests 
- [x] Added an entry to the CHANGELOG
