### PR TITLE
Not nil schema filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * New dataloader, querying, evaluate and compare apis - [#127](https://github.com/Gravity-Core/graphism/pull/127)
 * Cache relations properly - [#132](https://github.com/Gravity-Core/graphism/pull/132)
 * Safer query aliasing - [#133](https://github.com/Gravity-Core/graphism/pull/133)
+* Not nil schema filter - [#134](https://github.com/Gravity-Core/graphism/pull/134)
 
 ## 0.8.3 (September 6th, 2022)
 

--- a/lib/graphism/schema.ex
+++ b/lib/graphism/schema.ex
@@ -402,6 +402,10 @@ defmodule Graphism.Schema do
           end)
         )
 
+        defp do_filter(q, column_name, :neq, nil, binding) do
+          where(q, [{^binding, e}], not is_nil(field(e, ^column_name)))
+        end
+
         defp do_filter(q, column_name, _, nil, binding) do
           where(q, [{^binding, e}], is_nil(field(e, ^column_name)))
         end


### PR DESCRIPTION
### Description

Support for not nil schema filters.

```elixir
# Get all posts with a least one comment
q = from p in Post, as: :post
Blog.Schema.filter(Post, [:comments], :neq, nil, q, :post)
```

### Checklist

- [ ] Added or modified tests 
- [x] Added an entry to the CHANGELOG
